### PR TITLE
chore: cardano-node-follower crate setup

### DIFF
--- a/hermes/Cargo.lock
+++ b/hermes/Cargo.lock
@@ -3,5 +3,9 @@
 version = 3
 
 [[package]]
+name = "cardano-chain-follower"
+version = "0.0.1"
+
+[[package]]
 name = "hermes"
 version = "0.0.1"

--- a/hermes/Cargo.toml
+++ b/hermes/Cargo.toml
@@ -2,7 +2,7 @@
 resolver = "2"
 members = [
     "bin",
-    # "crates/<a crate>",
+    "crates/cardano-chain-follower",
 ]
 
 [workspace.package]

--- a/hermes/crates/cardano-chain-follower/Cargo.toml
+++ b/hermes/crates/cardano-chain-follower/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "cardano-chain-follower"
+edition.workspace = true
+version.workspace = true
+authors.workspace = true
+rust-version.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+
+[dependencies]

--- a/hermes/crates/cardano-chain-follower/examples/basic.rs
+++ b/hermes/crates/cardano-chain-follower/examples/basic.rs
@@ -1,0 +1,5 @@
+//! Basic Cardano chain follower usage example.
+
+fn main() {
+    cardano_chain_follower::greet("World");
+}

--- a/hermes/crates/cardano-chain-follower/src/lib.rs
+++ b/hermes/crates/cardano-chain-follower/src/lib.rs
@@ -1,0 +1,6 @@
+//! Cardano chain follower.
+
+/// Greets a name.
+pub fn greet(name: &str) {
+    println!("Hello, {name}!");
+}


### PR DESCRIPTION
This PR adds an empty `cardano-node-follower` crate.

Closes #11.
