### PR TITLE
chore: use `COPY` command instead of `CP_SRC`

### DIFF
--- a/hermes/Earthfile
+++ b/hermes/Earthfile
@@ -8,7 +8,7 @@ builder:
 
     DO github.com/input-output-hk/catalyst-ci/earthly/rust:v2.0.3+SETUP --toolchain=rust-toolchain.toml
 
-    DO github.com/input-output-hk/catalyst-ci/earthly/rust:v2.0.3+CP_SRC --src=".cargo .config Cargo.* clippy.toml deny.toml rustfmt.toml bin crates"
+    COPY --dir .cargo .config Cargo.* clippy.toml deny.toml rustfmt.toml bin crates .
 
 # Test rust build container - Use best architecture host tools.
 check-hosted:


### PR DESCRIPTION
# Description

Remove `CP_SRC` UDC is a redundant command that could be replaced by the common `COPY` command.

## Related Issue(s)

> e.g., Closes #34 

## Description of Changes

* Removed `CP_SRC` UDC

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
