### PR TITLE
feat: genesis values helper

### DIFF
--- a/hermes/crates/cardano-chain-follower/src/lib.rs
+++ b/hermes/crates/cardano-chain-follower/src/lib.rs
@@ -9,7 +9,7 @@ use std::str::FromStr;
 pub use follow::*;
 pub use pallas::network::miniprotocols::Point;
 use pallas::{
-    ledger::traverse::MultiEraBlock,
+    ledger::traverse::{wellknown::GenesisValues, MultiEraBlock},
     network::miniprotocols::{
         chainsync, MAINNET_MAGIC, PREVIEW_MAGIC, PRE_PRODUCTION_MAGIC, TESTNET_MAGIC,
     },
@@ -115,6 +115,16 @@ impl From<Network> for u64 {
             Network::Preview => PREVIEW_MAGIC,
             Network::Testnet => TESTNET_MAGIC,
         }
+    }
+}
+
+/// Return genesis values for given network
+pub fn to_genesis_values(network: Network) -> Option<GenesisValues> {
+    match network {
+        Network::Mainnet => GenesisValues::from_magic(MAINNET_MAGIC),
+        Network::Preprod => GenesisValues::from_magic(PRE_PRODUCTION_MAGIC),
+        Network::Preview => GenesisValues::from_magic(PREVIEW_MAGIC),
+        Network::Testnet => GenesisValues::from_magic(TESTNET_MAGIC),
     }
 }
 

--- a/hermes/crates/cardano-chain-follower/src/lib.rs
+++ b/hermes/crates/cardano-chain-follower/src/lib.rs
@@ -119,7 +119,8 @@ impl From<Network> for u64 {
 }
 
 /// Return genesis values for given network
-pub fn network_genesis_values(network: Network) -> Option<GenesisValues> {
+#[must_use]
+pub fn network_genesis_values(network: &Network) -> Option<GenesisValues> {
     match network {
         Network::Mainnet => GenesisValues::from_magic(MAINNET_MAGIC),
         Network::Preprod => GenesisValues::from_magic(PRE_PRODUCTION_MAGIC),

--- a/hermes/crates/cardano-chain-follower/src/lib.rs
+++ b/hermes/crates/cardano-chain-follower/src/lib.rs
@@ -119,7 +119,7 @@ impl From<Network> for u64 {
 }
 
 /// Return genesis values for given network
-pub fn to_genesis_values(network: Network) -> Option<GenesisValues> {
+pub fn network_genesis_values(network: Network) -> Option<GenesisValues> {
     match network {
         Network::Mainnet => GenesisValues::from_magic(MAINNET_MAGIC),
         Network::Preprod => GenesisValues::from_magic(PRE_PRODUCTION_MAGIC),


### PR DESCRIPTION
Helper to obtain genesis values which are required for` block.epoch(genesis: &GenesisValues)` which in my use case; is consumed from the gateway.

Gateway->Follower->Pallas.

When consuming via catalyst gateway and importing pallas and the follower to satisfy types, conflicts emerge. It is cleaner to just import the follower and add this helper method.