### PR TITLE
chore(cardano-chain-follower): Use pallas 0.22.0 instead of catalyst-pallas

### DIFF
--- a/hermes/Cargo.toml
+++ b/hermes/Cargo.toml
@@ -50,10 +50,8 @@ unreachable = "deny"
 missing_docs_in_private_items = "deny"
 
 [workspace.dependencies]
-# Stop using catalyst-pallas once pallas changes are merged.
-# issue: https://github.com/input-output-hk/hermes/issues/63
-pallas = { version = "0.21.0", git = "https://github.com/input-output-hk/catalyst-pallas.git", branch = "feat/hardano-read-blocks-iter-send" }
-pallas-hardano = { version = "0.21.0", git = "https://github.com/input-output-hk/catalyst-pallas.git", branch = "feat/hardano-read-blocks-iter-send" }
+pallas = { version = "0.22.0" }
+pallas-hardano = { version = "0.22.0" }
 
 wasmtime = "17.0.0"
 rusty_ulid = "2.0.0"


### PR DESCRIPTION
# Description

Switch back to using `pallas` (v0.22.0) instead of the `catalyst-pallas` fork.

## Related Issue(s)

Closes #63.

## Please confirm the following checks

* [ ] My code follows the style guidelines of this project
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
