### PR TITLE
feat: Update `wasm::Module` to enable wasm component model 

### DIFF
--- a/hermes/bin/src/event.rs
+++ b/hermes/bin/src/event.rs
@@ -1,0 +1,16 @@
+pub trait HermesEventPayload<ModuleInstance> {
+    /// Returns the name of the event associated with the payload.
+    fn event_name(&self) -> &str;
+
+    /// Executes the behavior associated with the payload, using the provided Hermes
+    /// bindings and state store.
+    ///
+    /// # Arguments
+    ///
+    /// * `instance` - The Hermes instance to use for executing the payload's behavior.
+    ///
+    /// # Returns
+    ///
+    /// An `anyhow::Result` indicating the success or failure of the payload execution.
+    fn execute(&self, instance: &mut ModuleInstance) -> anyhow::Result<()>;
+}

--- a/hermes/bin/src/event.rs
+++ b/hermes/bin/src/event.rs
@@ -6,7 +6,7 @@ pub trait HermesEventPayload<Executor> {
     ///
     /// # Arguments
     ///
-    /// * `executor` - The  to use for executing the payload's behavior.
+    /// * `executor` - The executor to use for executing the payload's behavior.
     ///
     /// # Returns
     ///

--- a/hermes/bin/src/event.rs
+++ b/hermes/bin/src/event.rs
@@ -1,3 +1,6 @@
+//! Hermes event definition
+
+/// A trait for defining the behavior of a Hermes event.
 pub trait HermesEventPayload<Executor> {
     /// Returns the name of the event associated with the payload.
     fn event_name(&self) -> &str;

--- a/hermes/bin/src/event.rs
+++ b/hermes/bin/src/event.rs
@@ -1,16 +1,15 @@
-pub trait HermesEventPayload<ModuleInstance> {
+pub trait HermesEventPayload<Executor> {
     /// Returns the name of the event associated with the payload.
     fn event_name(&self) -> &str;
 
-    /// Executes the behavior associated with the payload, using the provided Hermes
-    /// bindings and state store.
+    /// Executes the behavior associated with the payload, using the provided executor.
     ///
     /// # Arguments
     ///
-    /// * `instance` - The Hermes instance to use for executing the payload's behavior.
+    /// * `executor` - The  to use for executing the payload's behavior.
     ///
     /// # Returns
     ///
     /// An `anyhow::Result` indicating the success or failure of the payload execution.
-    fn execute(&self, instance: &mut ModuleInstance) -> anyhow::Result<()>;
+    fn execute(&self, executor: &mut Executor) -> anyhow::Result<()>;
 }

--- a/hermes/bin/src/lib.rs
+++ b/hermes/bin/src/lib.rs
@@ -1,4 +1,7 @@
 //! Intentionally empty
 //! This file exists, so that doc tests can be used inside binary crates.
 
-mod wasm;
+#[allow(dead_code, missing_docs, clippy::missing_docs_in_private_items)]
+pub(crate) mod event;
+mod runtime;
+pub(crate) mod wasm;

--- a/hermes/bin/src/lib.rs
+++ b/hermes/bin/src/lib.rs
@@ -1,7 +1,6 @@
 //! Intentionally empty
 //! This file exists, so that doc tests can be used inside binary crates.
 
-#[allow(dead_code, missing_docs, clippy::missing_docs_in_private_items)]
 pub(crate) mod event;
 mod runtime;
 pub(crate) mod wasm;

--- a/hermes/bin/src/main.rs
+++ b/hermes/bin/src/main.rs
@@ -1,6 +1,5 @@
 //! The Hermes Node.
 
-#[allow(dead_code, missing_docs, clippy::missing_docs_in_private_items)]
 pub(crate) mod event;
 mod runtime;
 pub(crate) mod wasm;

--- a/hermes/bin/src/main.rs
+++ b/hermes/bin/src/main.rs
@@ -1,7 +1,9 @@
 //! The Hermes Node.
 
+#[allow(dead_code, missing_docs, clippy::missing_docs_in_private_items)]
+pub(crate) mod event;
 mod runtime;
-mod wasm;
+pub(crate) mod wasm;
 
 fn main() {
     println!("Hello, world!");

--- a/hermes/bin/src/wasm/context.rs
+++ b/hermes/bin/src/wasm/context.rs
@@ -31,8 +31,8 @@ impl Context {
     }
 
     /// Increments the module's execution counter and sets the event name to be executed
-    pub(crate) fn use_for(&mut self, even_name: String) {
-        self.event_name = Some(even_name);
+    pub(crate) fn use_for(&mut self, event_name: String) {
+        self.event_name = Some(event_name);
         self.counter += 1;
     }
 

--- a/hermes/bin/src/wasm/engine.rs
+++ b/hermes/bin/src/wasm/engine.rs
@@ -1,10 +1,7 @@
 //! WASM engine implementation
 //! Wrapper over the `wasmtime::Engine` struct with some specific configuration setup.
 
-use std::{
-    error::Error,
-    ops::{Deref, DerefMut},
-};
+use std::ops::{Deref, DerefMut};
 
 use wasmtime::{Config as WasmConfig, Engine as WasmEngine};
 
@@ -33,7 +30,7 @@ impl Engine {
     ///
     /// - `wasmtime::Error`: engine initialization error.
     #[allow(dead_code)]
-    pub(crate) fn new() -> Result<Self, Box<dyn Error>> {
+    pub(crate) fn new() -> anyhow::Result<Self> {
         let mut config = WasmConfig::new();
         config.wasm_component_model(true);
         config.consume_fuel(false);

--- a/hermes/bin/src/wasm/mod.rs
+++ b/hermes/bin/src/wasm/mod.rs
@@ -2,5 +2,5 @@
 //! All implementation based on [wasmtime](https://crates.io/crates/wasmtime) crate dependency.
 
 pub(crate) mod context;
-mod engine;
-mod module;
+pub(crate) mod engine;
+pub(crate) mod module;

--- a/hermes/bin/src/wasm/module.rs
+++ b/hermes/bin/src/wasm/module.rs
@@ -127,11 +127,7 @@ mod tests {
 
     struct TestHost;
     impl Host<Context> for TestHost {
-        fn link_imports(linker: &mut WasmLinker<Context>) -> anyhow::Result<()> {
-            linker.instance("")?.func_wrap("hello", |_, ()| {
-                println!("hello");
-                Ok(())
-            })?;
+        fn link_imports(_linker: &mut WasmLinker<Context>) -> anyhow::Result<()> {
             Ok(())
         }
     }

--- a/hermes/bin/src/wasm/module.rs
+++ b/hermes/bin/src/wasm/module.rs
@@ -38,13 +38,20 @@ impl Instance for WasmInstance {
     }
 }
 
-#[allow(dead_code)]
+/// Structure defines an abstraction over the WASM module instance.
+/// It holds the state of the WASM module along with its context data.
+/// It is used to interact with the WASM module.
 pub(crate) struct ModuleInstance<I: Instance> {
-    store: WasmStore<Context>,
-    instance: I,
+    /// `wasmtime::Store` entity
+    #[allow(dead_code)]
+    pub(crate) store: WasmStore<Context>,
+    /// `Instance` entity
+    #[allow(dead_code)]
+    pub(crate) instance: I,
 }
 
 impl<I: Instance> ModuleInstance<I> {
+    /// Instantiates WASM module
     pub(crate) fn new(
         mut store: WasmStore<Context>, pre_instance: &WasmInstancePre<Context>,
     ) -> anyhow::Result<Self> {
@@ -76,6 +83,7 @@ pub(crate) struct Module<H: Host<Context>> {
     /// `Context` entity
     context: Context,
 
+    /// `Host` type
     _host: std::marker::PhantomData<H>,
 }
 
@@ -102,7 +110,10 @@ impl<H: Host<Context>> Module<H> {
         })
     }
 
-    /// Call WASM module's function.
+    /// Executes a Hermes event by calling some WASM function.
+    /// This function abstraction over actual execution of the WASM function,
+    /// actuall definition is inside `HermesEventPayload` trait implementation.
+    ///
     /// For each call creates a brand new `wasmtime::Store` instance, which means that
     /// is has an initial state, based on the provided context for each call.
     ///

--- a/hermes/bin/src/wasm/module.rs
+++ b/hermes/bin/src/wasm/module.rs
@@ -4,8 +4,6 @@
 //!
 //! All implementation based on [wasmtime](https://crates.io/crates/wasmtime) crate dependency.
 
-use std::error::Error;
-
 use wasmtime::{
     InstancePre as WasmInstancePre, Linker as WasmLinker, Module as WasmModule, Store as WasmStore,
 };
@@ -85,7 +83,7 @@ impl<H: Host<Context>> Module<H> {
     #[allow(dead_code)]
     pub(crate) fn new(
         engine: Engine, app_name: String, module_bytes: &[u8],
-    ) -> Result<Self, Box<dyn Error>> {
+    ) -> anyhow::Result<Self> {
         let module = WasmModule::new(&engine, module_bytes)?;
 
         let mut linker = WasmLinker::new(&engine);
@@ -109,12 +107,12 @@ impl<H: Host<Context>> Module<H> {
     #[allow(dead_code)]
     pub(crate) fn execute_event<I: WasmInstance>(
         &mut self, event: &impl HermesEventPayload<ModuleInstance<I>>,
-    ) -> Result<(), Box<dyn Error>> {
+    ) -> anyhow::Result<()> {
         self.context.use_for(event.event_name().to_string());
 
         let store = WasmStore::new(&self.engine, self.context.clone());
-        let mut intance = ModuleInstance::new(store, &self.pre_instance)?;
-        event.execute(&mut intance)?;
+        let mut instance = ModuleInstance::new(store, &self.pre_instance)?;
+        event.execute(&mut instance)?;
         Ok(())
     }
 }


### PR DESCRIPTION
# Description

Updated current `wasm::Module` implementation to be aligned with the WASM component model design

## Related Issue(s)

Part of #109

## Description of Changes

- added `event::HermesEventPayload` trait as a Hermes event abstraction.
- updated `wasm::Module` implementation. `wasm::Module` incapsulates the logic around "How to load wasm module", "How to prepare a WASM environment for every execution of the wasm module. Also `wasm::Module` does not responsible and does not answering the question "How to execute wasm function", this functionality is generalised with the help of `wasm::module::Instance` trait and `event::HermesEventPayload` trait.


