### PR TITLE
feat: follower connection

### DIFF
--- a/hermes/crates/cardano-chain-follower/examples/follow_chain_updates_mithril.rs
+++ b/hermes/crates/cardano-chain-follower/examples/follow_chain_updates_mithril.rs
@@ -41,7 +41,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     .await?;
 
     // Wait for some chain updates and shutdown.
-    loop {
+    for _ in 0..10 {
         let chain_update = follower.next().await?;
 
         match chain_update {
@@ -67,6 +67,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
             },
         }
     }
+
+    follower.close().await?;
+
+    Ok(())
 
     // Waits for the follower background task to exit.
 }

--- a/hermes/crates/cardano-chain-follower/examples/follow_chain_updates_mithril.rs
+++ b/hermes/crates/cardano-chain-follower/examples/follow_chain_updates_mithril.rs
@@ -41,7 +41,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     .await?;
 
     // Wait for some chain updates and shutdown.
-    for _ in 0..10 {
+    loop {
         let chain_update = follower.next().await?;
 
         match chain_update {
@@ -69,7 +69,4 @@ async fn main() -> Result<(), Box<dyn Error>> {
     }
 
     // Waits for the follower background task to exit.
-    follower.close().await?;
-
-    Ok(())
 }

--- a/hermes/crates/cardano-chain-follower/examples/follow_chain_updates_mithril.rs
+++ b/hermes/crates/cardano-chain-follower/examples/follow_chain_updates_mithril.rs
@@ -68,9 +68,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
         }
     }
 
+    // Waits for the follower background task to exit.
     follower.close().await?;
 
     Ok(())
-
-    // Waits for the follower background task to exit.
 }

--- a/hermes/crates/cardano-chain-follower/src/follow.rs
+++ b/hermes/crates/cardano-chain-follower/src/follow.rs
@@ -72,9 +72,7 @@ impl FollowerConfigBuilder {
     /// * `from`: Sync starting point.
     #[must_use]
     pub fn follow_from<P>(mut self, from: P) -> Self
-    where
-        P: Into<PointOrTip>,
-    {
+    where P: Into<PointOrTip> {
         self.follow_from = from.into();
         self
     }
@@ -271,9 +269,7 @@ impl Follower {
     ///
     /// Returns Err if something went wrong while communicating with the producer.
     pub async fn set_read_pointer<P>(&self, at: P) -> Result<Option<Point>>
-    where
-        P: Into<PointOrTip>,
-    {
+    where P: Into<PointOrTip> {
         let (response_tx, response_rx) = oneshot::channel();
 
         let req = task::Request::SetReadPointer {
@@ -298,9 +294,7 @@ impl Follower {
     /// * `at`: Point at which to read the block.
     #[must_use]
     pub fn read_block<P>(&self, at: P) -> ReadBlock
-    where
-        P: Into<PointOrTip>,
-    {
+    where P: Into<PointOrTip> {
         ReadBlock(
             at.into(),
             self.client_connect_info.clone(),
@@ -316,9 +310,7 @@ impl Follower {
     /// * `to`: Block range end.
     #[must_use]
     pub fn read_block_range<P>(&self, from: Point, to: P) -> ReadBlockRange
-    where
-        P: Into<PointOrTip>,
-    {
+    where P: Into<PointOrTip> {
         ReadBlockRange(
             from,
             to.into(),
@@ -447,9 +439,11 @@ mod task {
         mut request_rx: mpsc::Receiver<Request>,
         chain_update_tx: mpsc::Sender<crate::Result<ChainUpdate>>,
     ) {
-        let mithril_snapshot_state = mithril_snapshot.map(|snapshot| MithrilSnapshotState {
-            snapshot,
-            iter: None,
+        let mithril_snapshot_state = mithril_snapshot.map(|snapshot| {
+            MithrilSnapshotState {
+                snapshot,
+                iter: None,
+            }
         });
 
         let task_state = TaskState {
@@ -820,24 +814,30 @@ mod task {
         client: &mut PeerClient, at: PointOrTip,
     ) -> Result<Option<Point>> {
         match at {
-            PointOrTip::Point(Point::Origin) => client
-                .chainsync()
-                .intersect_origin()
-                .await
-                .map(Some)
-                .map_err(Error::Chainsync),
-            PointOrTip::Point(p @ Point::Specific(..)) => client
-                .chainsync()
-                .find_intersect(vec![p])
-                .await
-                .map(|(point, _)| point)
-                .map_err(Error::Chainsync),
-            PointOrTip::Tip => client
-                .chainsync()
-                .intersect_tip()
-                .await
-                .map(Some)
-                .map_err(Error::Chainsync),
+            PointOrTip::Point(Point::Origin) => {
+                client
+                    .chainsync()
+                    .intersect_origin()
+                    .await
+                    .map(Some)
+                    .map_err(Error::Chainsync)
+            },
+            PointOrTip::Point(p @ Point::Specific(..)) => {
+                client
+                    .chainsync()
+                    .find_intersect(vec![p])
+                    .await
+                    .map(|(point, _)| point)
+                    .map_err(Error::Chainsync)
+            },
+            PointOrTip::Tip => {
+                client
+                    .chainsync()
+                    .intersect_tip()
+                    .await
+                    .map(Some)
+                    .map_err(Error::Chainsync)
+            },
         }
     }
 

--- a/hermes/crates/cardano-chain-follower/src/follow.rs
+++ b/hermes/crates/cardano-chain-follower/src/follow.rs
@@ -72,7 +72,9 @@ impl FollowerConfigBuilder {
     /// * `from`: Sync starting point.
     #[must_use]
     pub fn follow_from<P>(mut self, from: P) -> Self
-    where P: Into<PointOrTip> {
+    where
+        P: Into<PointOrTip>,
+    {
         self.follow_from = from.into();
         self
     }
@@ -100,6 +102,7 @@ impl FollowerConfigBuilder {
 }
 
 /// Configuration for the Cardano chain follower.
+#[derive(Clone)]
 pub struct FollowerConfig {
     /// Configured chain update buffer size.
     pub chain_update_buffer_size: usize,
@@ -268,7 +271,9 @@ impl Follower {
     ///
     /// Returns Err if something went wrong while communicating with the producer.
     pub async fn set_read_pointer<P>(&self, at: P) -> Result<Option<Point>>
-    where P: Into<PointOrTip> {
+    where
+        P: Into<PointOrTip>,
+    {
         let (response_tx, response_rx) = oneshot::channel();
 
         let req = task::Request::SetReadPointer {
@@ -293,7 +298,9 @@ impl Follower {
     /// * `at`: Point at which to read the block.
     #[must_use]
     pub fn read_block<P>(&self, at: P) -> ReadBlock
-    where P: Into<PointOrTip> {
+    where
+        P: Into<PointOrTip>,
+    {
         ReadBlock(
             at.into(),
             self.client_connect_info.clone(),
@@ -309,7 +316,9 @@ impl Follower {
     /// * `to`: Block range end.
     #[must_use]
     pub fn read_block_range<P>(&self, from: Point, to: P) -> ReadBlockRange
-    where P: Into<PointOrTip> {
+    where
+        P: Into<PointOrTip>,
+    {
         ReadBlockRange(
             from,
             to.into(),
@@ -438,11 +447,9 @@ mod task {
         mut request_rx: mpsc::Receiver<Request>,
         chain_update_tx: mpsc::Sender<crate::Result<ChainUpdate>>,
     ) {
-        let mithril_snapshot_state = mithril_snapshot.map(|snapshot| {
-            MithrilSnapshotState {
-                snapshot,
-                iter: None,
-            }
+        let mithril_snapshot_state = mithril_snapshot.map(|snapshot| MithrilSnapshotState {
+            snapshot,
+            iter: None,
         });
 
         let task_state = TaskState {
@@ -813,30 +820,24 @@ mod task {
         client: &mut PeerClient, at: PointOrTip,
     ) -> Result<Option<Point>> {
         match at {
-            PointOrTip::Point(Point::Origin) => {
-                client
-                    .chainsync()
-                    .intersect_origin()
-                    .await
-                    .map(Some)
-                    .map_err(Error::Chainsync)
-            },
-            PointOrTip::Point(p @ Point::Specific(..)) => {
-                client
-                    .chainsync()
-                    .find_intersect(vec![p])
-                    .await
-                    .map(|(point, _)| point)
-                    .map_err(Error::Chainsync)
-            },
-            PointOrTip::Tip => {
-                client
-                    .chainsync()
-                    .intersect_tip()
-                    .await
-                    .map(Some)
-                    .map_err(Error::Chainsync)
-            },
+            PointOrTip::Point(Point::Origin) => client
+                .chainsync()
+                .intersect_origin()
+                .await
+                .map(Some)
+                .map_err(Error::Chainsync),
+            PointOrTip::Point(p @ Point::Specific(..)) => client
+                .chainsync()
+                .find_intersect(vec![p])
+                .await
+                .map(|(point, _)| point)
+                .map_err(Error::Chainsync),
+            PointOrTip::Tip => client
+                .chainsync()
+                .intersect_tip()
+                .await
+                .map(Some)
+                .map_err(Error::Chainsync),
         }
     }
 


### PR DESCRIPTION
Currently if the follower cannot find the mithril snapshot, it just returns an error `Error: MithrilSnapshot `

However, I was hoping we could abstract this failure and return a follower regardless i.e if it cant bootstrap from the snapshot it should return a follower which is consuming from a network. 

Maybe i'm wrong and there's an easier cleaner way, but I had to do the following to mimic the behavior described above on the consumer side.

The PR requires the `FollowerConfig` is **cloneable** for this code to work because of the move.

We can just use the below code for now (if there is no other way) and add the suggestions to the follower at a later date or address it soon on the follower side of things.

I could be way off and missing something. Please let me know.

```rust 

/// In the context of setting up the follower connection.
/// If there is metadata present which allows us to bootstrap from a point in time
/// We start from there, if not; we start from genesis.
async fn follower_connection(
    start_from: (Option<SlotNumber>, Option<BlockHash>), snapshot: &str, network: Network,
    relay: &str,
) -> Result<Follower, Box<dyn Error>> {
    let mut follower_cfg = if start_from.0.is_none() || start_from.1.is_none() {
        // start from genesis, no previous followers, hence no starting points.
        FollowerConfigBuilder::default()
            .mithril_snapshot_path(PathBuf::from(snapshot))
            .build()
    } else {
        // start from given point
        FollowerConfigBuilder::default()
            .follow_from(Point::new(
                start_from.0.ok_or("Slot number not present")?.try_into()?,
                hex::decode(start_from.1.ok_or("Block Hash not present")?)?,
            ))
            .mithril_snapshot_path(PathBuf::from(snapshot))
            .build()
    };

    let follower = match Follower::connect(&relay, network, follower_cfg).await {
        Ok(follower) => follower,
        Err(err) => {
            error!(
                "Unable to bootstrap via mithril snapshot {}. Trying network..",
                err
            );
           
            // We know bootstrapping from the snapshot fails, remove path for it to try from network
            follower_cfg.mithril_snapshot_path = None;
            Follower::connect(&relay, network, follower_cfg).await?
        },
    };

    Ok(follower)
}



```