### PR TITLE
fix(cardano-chain-follower): Refactor cardano-chain-follower to fix client concurrency bug

### DIFF
--- a/docs/src/architecture/08_concepts/cardano_chain_follower/overview.md
+++ b/docs/src/architecture/08_concepts/cardano_chain_follower/overview.md
@@ -20,9 +20,6 @@ The chain follower is capable of receiving chain updates from a Cardano node usi
 ### Read pointer
 
 The read pointer points at the location the chain is being read by a client connection.
-Although the Cardano node maintains a read pointer for each client, the chain follower manages
-its own copy of the read pointer in order to follow the chain even when it's reading data from a Mithril snapshot.
-The follower's read pointer gets updated every time it receives a chain update.
 
 ### Chain Updates
 

--- a/hermes/crates/cardano-chain-follower/examples/concurrent_reads.rs
+++ b/hermes/crates/cardano-chain-follower/examples/concurrent_reads.rs
@@ -1,0 +1,78 @@
+//! This example shows how to use the chain follower to download arbitrary blocks
+//! from the chain concurrently.
+
+use std::error::Error;
+
+use cardano_chain_follower::{Follower, FollowerConfigBuilder, Network, Point};
+use tracing::level_filters::LevelFilter;
+use tracing_subscriber::EnvFilter;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::builder()
+                .with_default_directive(LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    let config = FollowerConfigBuilder::default().build();
+
+    let follower = Follower::connect(
+        "relays-new.cardano-mainnet.iohk.io:3001",
+        Network::Mainnet,
+        config,
+    )
+    .await?;
+
+    let points = vec![
+        Point::Specific(
+            110_908_236,
+            hex::decode("ad3798a1db2b6097c71f35609399e4b2ff834f0f45939803d563bf9d660df2f2")?,
+        ),
+        Point::Specific(
+            110_908_582,
+            hex::decode("16e97a73e866280582ee1201a5e1815993978eede956af1869b0733bedc131f2")?,
+        ),
+    ];
+    let mut point_count = points.len();
+
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+
+    for p in points {
+        let slot_no = p.slot_or_default();
+        let r = follower.read_block(p);
+        let r_tx = tx.clone();
+
+        tokio::spawn(async move {
+            tracing::info!(slot_no, "Reading block");
+            let result = r.await;
+            drop(r_tx.send(result));
+        });
+    }
+
+    while let Some(result) = rx.recv().await {
+        let block_data = result?;
+        let block = block_data.decode()?;
+
+        let total_fee = block
+            .txs()
+            .iter()
+            .map(|tx| tx.fee().unwrap_or_default())
+            .sum::<u64>();
+
+        println!(
+            "Block {} (slot {}) => total fee: {total_fee}",
+            block.number(),
+            block.slot()
+        );
+
+        point_count -= 1;
+        if point_count == 0 {
+            break;
+        }
+    }
+
+    Ok(())
+}

--- a/hermes/crates/cardano-chain-follower/examples/read_block.rs
+++ b/hermes/crates/cardano-chain-follower/examples/read_block.rs
@@ -1,4 +1,4 @@
-//! This example shows how to use the chain reader to download arbitrary blocks
+//! This example shows how to use the chain follower to download arbitrary blocks
 //! from the chain.
 
 use std::error::Error;

--- a/hermes/crates/cardano-chain-follower/examples/read_block.rs
+++ b/hermes/crates/cardano-chain-follower/examples/read_block.rs
@@ -31,7 +31,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
             110_908_236,
             hex::decode("ad3798a1db2b6097c71f35609399e4b2ff834f0f45939803d563bf9d660df2f2")?,
         ))
-        .read()
         .await?;
 
     let block = data.decode()?;

--- a/hermes/crates/cardano-chain-follower/examples/read_block_mithril.rs
+++ b/hermes/crates/cardano-chain-follower/examples/read_block_mithril.rs
@@ -1,4 +1,4 @@
-//! This example shows how to use the chain reader to read arbitrary blocks
+//! This example shows how to use the chain follower to read arbitrary blocks
 //! from Mithril snapshot files.
 
 // Allowing since this is example code.

--- a/hermes/crates/cardano-chain-follower/examples/read_block_mithril.rs
+++ b/hermes/crates/cardano-chain-follower/examples/read_block_mithril.rs
@@ -40,7 +40,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
             49_075_418,
             hex::decode("bdb5ce7788850c30342794f252b1d955086862e8f7cb90a32a8f560b693ca78a")?,
         ))
-        .read()
         .await?;
 
     let block = data.decode()?;

--- a/hermes/crates/cardano-chain-follower/examples/read_block_range.rs
+++ b/hermes/crates/cardano-chain-follower/examples/read_block_range.rs
@@ -1,4 +1,4 @@
-//! This example shows how to use the chain reader to download arbitrary blocks
+//! This example shows how to use the chain follower to download arbitrary blocks
 //! from the chain.
 
 use std::error::Error;

--- a/hermes/crates/cardano-chain-follower/examples/read_block_range.rs
+++ b/hermes/crates/cardano-chain-follower/examples/read_block_range.rs
@@ -37,7 +37,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 hex::decode("16e97a73e866280582ee1201a5e1815993978eede956af1869b0733bedc131f2")?,
             ),
         )
-        .read()
         .await?;
 
     let mut total_txs = 0;

--- a/hermes/crates/cardano-chain-follower/examples/read_block_range_mithril.rs
+++ b/hermes/crates/cardano-chain-follower/examples/read_block_range_mithril.rs
@@ -48,7 +48,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 hex::decode("b7639b523f320643236ab0fc04b7fd381dedd42c8d6b6433b5965a5062411396")?,
             ),
         )
-        .read()
         .await?;
 
     for data in data_vec {

--- a/hermes/crates/cardano-chain-follower/examples/read_block_range_mithril.rs
+++ b/hermes/crates/cardano-chain-follower/examples/read_block_range_mithril.rs
@@ -1,4 +1,4 @@
-//! This example shows how to use the chain reader to read arbitrary blocks
+//! This example shows how to use the chain follower to read arbitrary blocks
 //! from Mithril snapshot files.
 
 // Allowing since this is example code.

--- a/hermes/crates/cardano-chain-follower/examples/set_read_pointer.rs
+++ b/hermes/crates/cardano-chain-follower/examples/set_read_pointer.rs
@@ -1,0 +1,73 @@
+//! This example shows how to use the chain follower to follow chain updates on
+//! a Cardano network chain.
+
+use std::error::Error;
+
+use cardano_chain_follower::{ChainUpdate, Follower, FollowerConfigBuilder, Network, Point};
+use tracing::level_filters::LevelFilter;
+use tracing_subscriber::EnvFilter;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::builder()
+                .with_default_directive(LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    // Defaults to start following from the tip.
+    let config = FollowerConfigBuilder::default().build();
+
+    let mut follower = Follower::connect(
+        "relays-new.cardano-mainnet.iohk.io:3001",
+        Network::Mainnet,
+        config,
+    )
+    .await?;
+
+    let mut starting_point = Point::Origin;
+
+    for _ in 0..2 {
+        for _ in 0..3 {
+            let chain_update = follower.next().await?;
+
+            match chain_update {
+                ChainUpdate::Block(data) => {
+                    let block = data.decode()?;
+
+                    println!(
+                        "New block NUMBER={} SLOT={} HASH={}",
+                        block.number(),
+                        block.slot(),
+                        hex::encode(block.hash()),
+                    );
+
+                    if starting_point == Point::Origin {
+                        starting_point = Point::Specific(block.slot(), block.hash().to_vec());
+                    }
+                },
+                ChainUpdate::Rollback(data) => {
+                    let block = data.decode()?;
+
+                    println!(
+                        "Rollback block NUMBER={} SLOT={} HASH={}",
+                        block.number(),
+                        block.slot(),
+                        hex::encode(block.hash()),
+                    );
+                },
+            }
+        }
+
+        // Set the read pointer back to the first point we received.
+        // This means the next chain update will be the block right after the starting point.
+        follower.set_read_pointer(starting_point.clone()).await?;
+    }
+
+    // Waits for the follower background task to exit.
+    follower.close().await?;
+
+    Ok(())
+}

--- a/hermes/crates/cardano-chain-follower/examples/set_read_pointer.rs
+++ b/hermes/crates/cardano-chain-follower/examples/set_read_pointer.rs
@@ -1,4 +1,4 @@
-//! This example shows how set the follower's read pointer without stopping it.
+//! This example shows how to set the follower's read pointer without stopping it.
 
 use std::error::Error;
 

--- a/hermes/crates/cardano-chain-follower/src/follow.rs
+++ b/hermes/crates/cardano-chain-follower/src/follow.rs
@@ -344,7 +344,7 @@ impl Follower {
     ///
     /// Returns Err if some error occurred in the background task.
     pub async fn close(self) -> std::result::Result<(), tokio::task::JoinError> {
-        // NOTE(FelipeRosa): For now just abort all tasks since they need no cancelation
+        // NOTE(FelipeRosa): For now just abort all tasks since they need no cancellation
 
         self.task_join_handle.abort();
         self.read_task_join_handle.abort();
@@ -644,7 +644,7 @@ mod task {
             }
         }
 
-        /// Sends the next chain update throgh the follower's chain update channel.
+        /// Sends the next chain update through the follower's chain update channel.
         async fn send_next_chain_update(
             client: &mut PeerClient, chain_update_tx: mpsc::Sender<crate::Result<ChainUpdate>>,
         ) -> bool {

--- a/hermes/crates/cardano-chain-follower/src/follow.rs
+++ b/hermes/crates/cardano-chain-follower/src/follow.rs
@@ -461,7 +461,7 @@ mod task {
 
         /// Runs the follow task.
         ///
-        /// It keeps asking the connected node new chain updates. Every update and
+        /// It keeps asking the connected node for new chain updates. Every update and
         /// communication errors are sent through the channel to the follower.
         ///
         /// Backpressure is achieved with the chain update channel's limited size.

--- a/hermes/crates/cardano-chain-follower/src/follow.rs
+++ b/hermes/crates/cardano-chain-follower/src/follow.rs
@@ -72,9 +72,7 @@ impl FollowerConfigBuilder {
     /// * `from`: Sync starting point.
     #[must_use]
     pub fn follow_from<P>(mut self, from: P) -> Self
-    where
-        P: Into<PointOrTip>,
-    {
+    where P: Into<PointOrTip> {
         self.follow_from = from.into();
         self
     }
@@ -280,9 +278,7 @@ impl Follower {
     ///
     /// Returns Err if something went wrong while communicating with the producer.
     pub async fn set_read_pointer<P>(&self, at: P) -> Result<Option<Point>>
-    where
-        P: Into<PointOrTip>,
-    {
+    where P: Into<PointOrTip> {
         let (response_tx, response_rx) = oneshot::channel();
 
         let req = task::SetReadPointerRequest {
@@ -305,9 +301,7 @@ impl Follower {
     /// * `at`: Point at which to read the block.
     #[must_use]
     pub fn read_block<P>(&self, at: P) -> ReadBlock
-    where
-        P: Into<PointOrTip>,
-    {
+    where P: Into<PointOrTip> {
         ReadBlock(
             at.into(),
             self.client_connect_info.clone(),
@@ -323,9 +317,7 @@ impl Follower {
     /// * `to`: Block range end.
     #[must_use]
     pub fn read_block_range<P>(&self, from: Point, to: P) -> ReadBlockRange
-    where
-        P: Into<PointOrTip>,
-    {
+    where P: Into<PointOrTip> {
         ReadBlockRange(
             from,
             to.into(),
@@ -841,24 +833,30 @@ mod task {
 /// Sets the N2N remote client's read pointer.
 async fn set_client_read_pointer(client: &mut PeerClient, at: PointOrTip) -> Result<Option<Point>> {
     match at {
-        PointOrTip::Point(Point::Origin) => client
-            .chainsync()
-            .intersect_origin()
-            .await
-            .map(Some)
-            .map_err(Error::Chainsync),
-        PointOrTip::Point(p @ Point::Specific(..)) => client
-            .chainsync()
-            .find_intersect(vec![p])
-            .await
-            .map(|(point, _)| point)
-            .map_err(Error::Chainsync),
-        PointOrTip::Tip => client
-            .chainsync()
-            .intersect_tip()
-            .await
-            .map(Some)
-            .map_err(Error::Chainsync),
+        PointOrTip::Point(Point::Origin) => {
+            client
+                .chainsync()
+                .intersect_origin()
+                .await
+                .map(Some)
+                .map_err(Error::Chainsync)
+        },
+        PointOrTip::Point(p @ Point::Specific(..)) => {
+            client
+                .chainsync()
+                .find_intersect(vec![p])
+                .await
+                .map(|(point, _)| point)
+                .map_err(Error::Chainsync)
+        },
+        PointOrTip::Tip => {
+            client
+                .chainsync()
+                .intersect_tip()
+                .await
+                .map(Some)
+                .map_err(Error::Chainsync)
+        },
     }
 }
 

--- a/hermes/crates/cardano-chain-follower/src/lib.rs
+++ b/hermes/crates/cardano-chain-follower/src/lib.rs
@@ -30,12 +30,15 @@ pub enum Error {
     /// Chainsync protocol error.
     #[error("Chainsync error: {0:?}")]
     Chainsync(chainsync::ClientError),
-    /// Follower start point was not found.
-    #[error("Follower start point was not found")]
-    FollowerStartPointNotFound,
-    /// Follower background task has stopped.
-    #[error("Follower background task is not running")]
-    FollowerBackgroundTaskNotRunning,
+    /// Follower failed to set its read pointer.
+    #[error("Faield to set follower read pointer")]
+    SetReadPointer,
+    /// Follower background follow task has stopped.
+    #[error("Follower follow task is not running")]
+    FollowTaskNotRunning,
+    /// Follower background read task has stopped.
+    #[error("Follower read task is not running")]
+    ReadTaskNotRunning,
     /// Mithril snapshot error.
     #[error("Failed to read block(s) from Mithril snapshot")]
     MithrilSnapshot,

--- a/hermes/crates/cardano-chain-follower/src/lib.rs
+++ b/hermes/crates/cardano-chain-follower/src/lib.rs
@@ -31,7 +31,7 @@ pub enum Error {
     #[error("Chainsync error: {0:?}")]
     Chainsync(chainsync::ClientError),
     /// Follower failed to set its read pointer.
-    #[error("Faield to set follower read pointer")]
+    #[error("Failed to set follower read pointer")]
     SetReadPointer,
     /// Follower background follow task has stopped.
     #[error("Follower follow task is not running")]

--- a/hermes/crates/cardano-chain-follower/src/lib.rs
+++ b/hermes/crates/cardano-chain-follower/src/lib.rs
@@ -36,15 +36,15 @@ pub enum Error {
     /// Follower background follow task has stopped.
     #[error("Follower follow task is not running")]
     FollowTaskNotRunning,
-    /// Follower background read task has stopped.
-    #[error("Follower read task is not running")]
-    ReadTaskNotRunning,
     /// Mithril snapshot error.
     #[error("Failed to read block(s) from Mithril snapshot")]
     MithrilSnapshot,
     /// Failed to parse
     #[error("Failed to parse network")]
     ParseNetwork,
+    /// Internal Error
+    #[error("Internal error")]
+    InternalError,
 }
 
 /// Crate result type.

--- a/hermes/crates/cardano-chain-follower/src/mithril_snapshot.rs
+++ b/hermes/crates/cardano-chain-follower/src/mithril_snapshot.rs
@@ -22,6 +22,7 @@ impl Iterator for MithrilSnapshotIterator {
 }
 
 /// Holds information about a Mithril snapshot.
+#[derive(Clone)]
 pub(crate) struct MithrilSnapshot {
     /// Path to the Mithril snapshot.
     pub path: PathBuf,


### PR DESCRIPTION
# Description

This PR fixes a bug that caused the `Follower` to get stuck when trying to set its read pointer while waiting for the next chain update.

## Related Issue(s)

Closes #180 

## Description of Changes

### Background task

- `Follower` background task refactored to allow dropping the client and recreating it when setting the read pointer (which is needed because there seems to be no way of aborting an ongoing request to the node)
- Removed "read requests" from the follow task so the follow task is now only responsible for fetching chain updates and setting the read pointer when requested

### read_block and read_block_range
`Follower::read_block` and `Follower::read_block_range` now spawn futures and return join handles to make it possible to make read requests concurrently while not depending on the follower's background task.

### New examples

- Added `set_read_pointer` example that shows changing the follower's read pointer while following the chain
- Added `concurrent_reads` example that shows how to read chain blocks concurrently

## Breaking Changes

- Some variants of the crate's `Error` type were renamed/removed 
- `ReadBlock` and `ReadBlockRange` implement `Future` and should be awaited directly, i.e.: `follower.read_block().await` instead of `follower.read_block().read().await`

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
