### PR TITLE
chore(cardano-chain-follower): Add ways to get the raw bytes for MultiEraBlockData

### DIFF
--- a/hermes/crates/cardano-chain-follower/src/lib.rs
+++ b/hermes/crates/cardano-chain-follower/src/lib.rs
@@ -81,6 +81,18 @@ impl MultiEraBlockData {
 
         Ok(block)
     }
+
+    /// Consumes the [`MultiEraBlockData`] returning the block data raw bytes.
+    #[must_use]
+    pub fn into_raw_data(self) -> Vec<u8> {
+        self.0
+    }
+}
+
+impl AsRef<[u8]> for MultiEraBlockData {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
 }
 
 /// Enum of possible Cardano networks.


### PR DESCRIPTION
# Description

This PR adds functions to get the raw bytes from a `MultiEraBlockData` value.

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module