### PR TITLE
refactor: Add correspondent implementation for WASM package `Config` and `Settings` JSON object.

### DIFF
--- a/hermes/bin/src/packaging/schema_validation.rs
+++ b/hermes/bin/src/packaging/schema_validation.rs
@@ -16,6 +16,7 @@ pub(crate) struct SchemaValidator {
 
 impl SchemaValidator {
     /// Create a new json schema validator from reader.
+    #[allow(dead_code)]
     pub(crate) fn from_reader<R: Read>(reader: R) -> anyhow::Result<Self> {
         let schema = serde_json::from_reader(reader)?;
         Self::from_json(&schema)

--- a/hermes/bin/src/packaging/wasm_module/config.rs
+++ b/hermes/bin/src/packaging/wasm_module/config.rs
@@ -1,0 +1,64 @@
+//! WASM package config JSON
+
+use std::io::Read;
+
+use crate::packaging::schema_validation::SchemaValidator;
+
+/// Config schema object.
+#[derive(Debug)]
+pub(crate) struct ConfigSchema {
+    /// config schema JSON object.
+    json: serde_json::Map<String, serde_json::Value>,
+    /// JSON schema validator.
+    validator: SchemaValidator,
+}
+
+impl PartialEq for ConfigSchema {
+    fn eq(&self, other: &Self) -> bool {
+        self.json.eq(&other.json)
+    }
+}
+impl Eq for ConfigSchema {}
+
+impl ConfigSchema {
+    /// Create `ConfigSchema` from reader.
+    pub(crate) fn from_reader(reader: impl Read) -> anyhow::Result<Self> {
+        let json: serde_json::Map<_, _> = serde_json::from_reader(reader)?;
+        let validator = SchemaValidator::from_json(&serde_json::Value::Object(json.clone()))?;
+        Ok(Self { json, validator })
+    }
+
+    /// Convert `ConfigSchema` object to json bytes
+    pub(crate) fn to_bytes(&self) -> anyhow::Result<Vec<u8>> {
+        let bytes = serde_json::to_vec(&self.json)?;
+        Ok(bytes)
+    }
+
+    /// Get JSON schema validator.
+    pub(crate) fn validator(&self) -> &SchemaValidator {
+        &self.validator
+    }
+}
+
+/// Config object.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct Config {
+    /// config JSON object.
+    json: serde_json::Map<String, serde_json::Value>,
+}
+
+impl Config {
+    /// Create `Config` from reader.
+    pub(crate) fn from_reader(
+        reader: impl Read, validator: &SchemaValidator,
+    ) -> anyhow::Result<Self> {
+        let json = validator.deserialize_and_validate(reader)?;
+        Ok(Self { json })
+    }
+
+    /// Convert `Config` object to json bytes
+    pub(crate) fn to_bytes(&self) -> anyhow::Result<Vec<u8>> {
+        let bytes = serde_json::to_vec(&self.json)?;
+        Ok(bytes)
+    }
+}

--- a/hermes/bin/src/packaging/wasm_module/metadata.rs
+++ b/hermes/bin/src/packaging/wasm_module/metadata.rs
@@ -6,11 +6,11 @@ use chrono::{DateTime, Utc};
 
 use crate::packaging::schema_validation::SchemaValidator;
 
-/// Metadata object
+/// Metadata object.
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) struct Metadata {
-    /// metadata JSON object
-    object: serde_json::Map<String, serde_json::Value>,
+    /// metadata JSON object.
+    json: serde_json::Map<String, serde_json::Value>,
 }
 
 impl Metadata {
@@ -21,24 +21,24 @@ impl Metadata {
     /// Create `Metadata` from reader.
     pub(crate) fn from_reader(reader: impl Read) -> anyhow::Result<Self> {
         let schema_validator = SchemaValidator::from_str(Self::METADATA_SCHEMA)?;
-        let object = schema_validator.deserialize_and_validate(reader)?;
-        Ok(Self { object })
+        let json = schema_validator.deserialize_and_validate(reader)?;
+        Ok(Self { json })
     }
 
-    /// Convert `Metadata` object to json bytes
+    /// Convert `Metadata` object to json bytes.
     pub(crate) fn to_bytes(&self) -> anyhow::Result<Vec<u8>> {
-        let bytes = serde_json::to_vec(&self.object)?;
+        let bytes = serde_json::to_vec(&self.json)?;
         Ok(bytes)
     }
 
     /// Set `build_date` property to the `Metadata` object.
     pub(crate) fn set_build_date(&mut self, date: DateTime<Utc>) {
-        self.object
+        self.json
             .insert("build_date".to_string(), date.timestamp().into());
     }
 
     /// Set `name` property to the `Metadata` object.
     pub(crate) fn set_name(&mut self, name: &str) {
-        self.object.insert("name".to_string(), name.into());
+        self.json.insert("name".to_string(), name.into());
     }
 }

--- a/hermes/bin/src/packaging/wasm_module/settings.rs
+++ b/hermes/bin/src/packaging/wasm_module/settings.rs
@@ -1,0 +1,42 @@
+//! WASM package settings JSON
+
+use std::io::Read;
+
+use crate::packaging::schema_validation::SchemaValidator;
+
+/// Settings schema object.
+#[derive(Debug)]
+pub(crate) struct SettingsSchema {
+    /// settings schema JSON object.
+    json: serde_json::Map<String, serde_json::Value>,
+    /// JSON schema validator.
+    validator: SchemaValidator,
+}
+
+impl PartialEq for SettingsSchema {
+    fn eq(&self, other: &Self) -> bool {
+        self.json.eq(&other.json)
+    }
+}
+impl Eq for SettingsSchema {}
+
+impl SettingsSchema {
+    /// Create `SettingsSchema` from reader.
+    pub(crate) fn from_reader(reader: impl Read) -> anyhow::Result<Self> {
+        let json: serde_json::Map<_, _> = serde_json::from_reader(reader)?;
+        let validator = SchemaValidator::from_json(&serde_json::Value::Object(json.clone()))?;
+        Ok(Self { json, validator })
+    }
+
+    /// Convert `SettingsSchema` object to json bytes
+    pub(crate) fn to_bytes(&self) -> anyhow::Result<Vec<u8>> {
+        let bytes = serde_json::to_vec(&self.json)?;
+        Ok(bytes)
+    }
+
+    /// Get JSON schema validator.
+    #[allow(dead_code)]
+    pub(crate) fn validator(&self) -> &SchemaValidator {
+        &self.validator
+    }
+}


### PR DESCRIPTION
# Description

Made a minor refactor. Added structs for `ConfigSchema`, `Config` and `SettingsSchema` JSON objects.
Updated WASM package test.