### PR TITLE
fix(cardano-chain-follower): Correct multi era block tests

### DIFF
--- a/hermes/crates/cardano-chain-follower/src/multi_era_block_data.rs
+++ b/hermes/crates/cardano-chain-follower/src/multi_era_block_data.rs
@@ -350,7 +350,7 @@ mod tests {
 
             let previous_point = Point::new(
                 pallas_block.slot().add(i as u64),
-                pallas_block.header().previous_hash().unwrap().to_vec()
+                pallas_block.header().previous_hash().expect("cannot get previous hash").to_vec()
             );
 
             let block = MultiEraBlock::new(
@@ -400,7 +400,7 @@ mod tests {
 
             let previous_point = Point::new(
                 pallas_block.slot() - 1,
-                pallas_block.header().previous_hash().unwrap().to_vec()
+                pallas_block.header().previous_hash().expect("cannot get previous hash").to_vec()
             );
 
             let block = MultiEraBlock::new(
@@ -426,7 +426,7 @@ mod tests {
                 1,
             );
 
-            assert!(block.is_err())
+            assert!(block.is_err());
         }
     }
 

--- a/hermes/crates/cardano-chain-follower/src/multi_era_block_data.rs
+++ b/hermes/crates/cardano-chain-follower/src/multi_era_block_data.rs
@@ -275,6 +275,10 @@ impl PartialOrd<Point> for MultiEraBlock {
 
 #[cfg(test)]
 mod tests {
+    use std::ops::Add;
+
+    use anyhow::Ok;
+
     use crate::{point::ORIGIN_POINT, MultiEraBlock, Network, Point};
 
     struct TestRecord {
@@ -337,23 +341,104 @@ mod tests {
         ]
     }
 
+    /// Previous Point slot is >= blocks point, but hash is correct (should fail)
     #[test]
-    fn multi_era_block_test() {
-        for test_block in test_blocks() {
-            let block_bytes = hex::decode(test_block.raw).expect("Failed to decode hex block.");
+    fn test_multi_era_block_point_compare_1() -> anyhow::Result<(), anyhow::Error> {
+        for (i, test_block) in test_blocks().into_iter().enumerate() {
+            let pallas_block =
+                pallas::ledger::traverse::MultiEraBlock::decode(test_block.raw.as_slice())?;
+
+            let previous_point = Point::new(
+                pallas_block.slot().add(i as u64),
+                pallas_block.header().previous_hash().unwrap().to_vec()
+            );
+
             let block = MultiEraBlock::new(
                 Network::Preprod,
-                block_bytes.clone(),
+                test_block.raw.clone(),
+                &previous_point,
+                1,
+            );
+
+            assert!(block.is_err());
+        }
+        
+        Ok(())
+    }
+
+    /// Previous Point slot is < blocks point, but hash is different. (should fail).
+    #[test]
+    fn test_multi_era_block_point_compare_2() -> anyhow::Result<(), anyhow::Error> {
+        for test_block in test_blocks() {
+            let pallas_block =
+                pallas::ledger::traverse::MultiEraBlock::decode(test_block.raw.as_slice())?;
+
+            let previous_point = Point::new(
+                pallas_block.slot() - 1,
+                vec![0; 32]
+            );
+
+            let block = MultiEraBlock::new(
+                Network::Preprod,
+                test_block.raw.clone(),
+                &previous_point,
+                1,
+            );
+
+            assert!(block.is_err());
+        }
+        
+        Ok(())
+    }
+
+    #[test]
+    fn test_multi_era_block_with_origin_point() {
+        for test_block in test_blocks() {
+            let block = MultiEraBlock::new(
+                Network::Preprod,
+                test_block.raw.clone(),
                 &test_block.previous,
                 1,
-            )
-            .expect("Failed to decode block.");
+            );
+
+            assert!(block.is_err())
+        }
+    }
+
+    #[test]
+    fn test_multi_era_block_point_compare_previous_point() -> anyhow::Result<(), anyhow::Error> {
+        for test_block in test_blocks() {
             let pallas_block =
-                pallas::ledger::traverse::MultiEraBlock::decode(block_bytes.as_slice())
-                    .expect("Failed to decode pallas block.");
+                pallas::ledger::traverse::MultiEraBlock::decode(test_block.raw.as_slice())?;
+
+            let previous_point = Point::new(
+                pallas_block.slot() - 1,
+                pallas_block.header().previous_hash().unwrap().to_vec()
+            );
+
+            let block = MultiEraBlock::new(
+                Network::Preprod,
+                test_block.raw.clone(),
+                &previous_point,
+                1,
+            )?;
 
             assert_eq!(block.decode().hash(), pallas_block.hash());
         }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_multi_era_block_decode() -> anyhow::Result<(), anyhow::Error> {
+        for test_block in test_blocks() {
+            let pallas_block =
+                pallas::ledger::traverse::MultiEraBlock::decode(test_block.raw.as_slice())?;
+
+            assert!(!pallas_block.is_empty());
+        }
+
+        Ok(())
     }
 
     // #[test]

--- a/hermes/crates/cardano-chain-follower/src/multi_era_block_data.rs
+++ b/hermes/crates/cardano-chain-follower/src/multi_era_block_data.rs
@@ -106,7 +106,7 @@ impl MultiEraBlock {
                 ));
             }
         } else {
-            if *previous > slot {
+            if *previous >= slot {
                 return Err(Error::Codec(
                     "Previous slot is not less than current slot".to_string(),
                 ));

--- a/hermes/crates/cardano-chain-follower/src/multi_era_block_data.rs
+++ b/hermes/crates/cardano-chain-follower/src/multi_era_block_data.rs
@@ -391,22 +391,9 @@ mod tests {
         Ok(())
     }
 
+    /// Previous Point slot is < blocks point, and hash is also correct. (should pass).
     #[test]
-    fn test_multi_era_block_with_origin_point() {
-        for test_block in test_blocks() {
-            let block = MultiEraBlock::new(
-                Network::Preprod,
-                test_block.raw.clone(),
-                &test_block.previous,
-                1,
-            );
-
-            assert!(block.is_err())
-        }
-    }
-
-    #[test]
-    fn test_multi_era_block_point_compare_previous_point() -> anyhow::Result<(), anyhow::Error> {
+    fn test_multi_era_block_point_compare_3() -> anyhow::Result<(), anyhow::Error> {
         for test_block in test_blocks() {
             let pallas_block =
                 pallas::ledger::traverse::MultiEraBlock::decode(test_block.raw.as_slice())?;
@@ -427,6 +414,20 @@ mod tests {
         }
 
         Ok(())
+    }
+
+    #[test]
+    fn test_multi_era_block_with_origin_point() {
+        for test_block in test_blocks() {
+            let block = MultiEraBlock::new(
+                Network::Preprod,
+                test_block.raw.clone(),
+                &test_block.previous,
+                1,
+            );
+
+            assert!(block.is_err())
+        }
     }
 
     #[test]

--- a/hermes/crates/cardano-chain-follower/src/multi_era_block_data.rs
+++ b/hermes/crates/cardano-chain-follower/src/multi_era_block_data.rs
@@ -433,10 +433,7 @@ mod tests {
     #[test]
     fn test_multi_era_block_decode() -> anyhow::Result<(), anyhow::Error> {
         for test_block in test_blocks() {
-            let pallas_block =
-                pallas::ledger::traverse::MultiEraBlock::decode(test_block.raw.as_slice())?;
-
-            assert!(!pallas_block.is_empty());
+            pallas::ledger::traverse::MultiEraBlock::decode(test_block.raw.as_slice())?;
         }
 
         Ok(())


### PR DESCRIPTION
# Description

Correcting errors and test cases in the multi-era block module.

## Related Issue(s)

Closes [#603](https://github.com/input-output-hk/catalyst-voices/issues/603)

## Description of Changes

* Correct test cases in the multi-era block module
* Fix the validation on the block's previous point to throw error when use `>=` point as the current one.

## Please confirm the following checks

* [ ] My code follows the style guidelines of this project
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
