### PR TITLE
feat: Implement `std::io::Read`, `std::io::Write`, `std::io::Seek` for `hdf5::File`

### DIFF
--- a/hermes/bin/src/hdf5/dir.rs
+++ b/hermes/bin/src/hdf5/dir.rs
@@ -3,7 +3,6 @@
 use std::io::Read;
 
 use super::{
-    compression::enable_compression,
     resources::{Hdf5Resource, ResourceTrait},
     File, Path,
 };
@@ -53,11 +52,7 @@ impl Dir {
         }
 
         let dir = self.create_dir(&path)?;
-        let ds_builder = dir.0.new_dataset_builder();
-        enable_compression(ds_builder)
-            .with_data(&resource_data)
-            .create(file_name.as_str())?;
-
+        File::create(&dir.0, file_name.as_str(), &resource_data)?;
         Ok(())
     }
 
@@ -142,7 +137,7 @@ impl Dir {
         let dir = self.get_dir(&path)?;
         dir.0
             .dataset(file_name.as_str())
-            .map(File::new)
+            .map(File::open)
             .map_err(|_| anyhow::anyhow!("File {file_name}/{path} not found"))
     }
 
@@ -150,7 +145,7 @@ impl Dir {
     /// If path is empty it will return all child files of the current one.
     pub(crate) fn get_files(&self, path: &Path) -> anyhow::Result<Vec<File>> {
         let dir = self.get_dir(path)?;
-        Ok(dir.0.datasets()?.into_iter().map(File::new).collect())
+        Ok(dir.0.datasets()?.into_iter().map(File::open).collect())
     }
 
     /// Get dir by the provided path.

--- a/hermes/bin/src/hdf5/dir.rs
+++ b/hermes/bin/src/hdf5/dir.rs
@@ -263,14 +263,12 @@ mod tests {
         dir.copy_resource_file(&FsResource::new(file_1), file_1_name.into())
             .expect("Failed to copy file to package.");
 
-        let file_1 = dir
+        let mut file_1 = dir
             .get_file(file_1_name.into())
             .expect("Failed to get file.");
 
         let mut data = Vec::new();
         file_1
-            .reader()
-            .expect("Failed to get file reader.")
             .read_to_end(&mut data)
             .expect("Failed to read file's data.");
         assert_eq!(data.as_slice(), file_content);

--- a/hermes/bin/src/hdf5/file.rs
+++ b/hermes/bin/src/hdf5/file.rs
@@ -2,25 +2,130 @@
 
 use std::io::Read;
 
-use super::Path;
+use super::{compression::enable_compression, Path};
 
 /// Hermes HDF5 file object, wrapper of `hdf5::Dataset`
 #[derive(Clone, Debug)]
-pub(crate) struct File(hdf5::Dataset);
+pub(crate) struct File {
+    /// HDF5 dataset object.
+    hdf5_ds: hdf5::Dataset,
+    /// Reading/Writing position of the `hdf5_ds`.
+    pos: usize,
+}
 
 impl File {
-    /// Create new `File`.
-    pub(crate) fn new(dataset: hdf5::Dataset) -> Self {
-        Self(dataset)
+    /// Create a new file.
+    pub(crate) fn create(
+        group: &hdf5::Group, file_name: &str, data: &[u8],
+    ) -> anyhow::Result<Self> {
+        let builder = group.new_dataset_builder();
+        let shape = hdf5::SimpleExtents::resizable([data.len()]);
+
+        let hdf5_ds = enable_compression(builder)
+            .empty::<u8>()
+            .shape(shape)
+            .create(file_name)?;
+        hdf5_ds.write(data)?;
+        Ok(Self { hdf5_ds, pos: 0 })
+    }
+
+    /// Open an existing `File` from the provided dataset.
+    pub(crate) fn open(hdf5_ds: hdf5::Dataset) -> Self {
+        Self { hdf5_ds, pos: 0 }
     }
 
     /// Return file `Path`.
     pub(crate) fn path(&self) -> Path {
-        Path::from_str(&self.0.name())
+        Path::from_str(&self.hdf5_ds.name())
     }
 
     /// Return file reader.
     pub(crate) fn reader(&self) -> anyhow::Result<impl Read> {
-        Ok(self.0.as_byte_reader()?)
+        Ok(self.hdf5_ds.as_byte_reader()?)
+    }
+
+    /// Return file size.
+    fn size(&self) -> anyhow::Result<usize> {
+        let dataspace = self.hdf5_ds.space()?;
+        let shape = dataspace.shape();
+        let size = shape
+            .first()
+            .ok_or(anyhow::anyhow!("Failed to get file size.",))?;
+        Ok(*size)
+    }
+}
+
+/// Convert arbitrary error to `std::io::Error`.
+#[allow(clippy::needless_pass_by_value)]
+fn map_to_io_error(err: impl ToString) -> std::io::Error {
+    std::io::Error::new(std::io::ErrorKind::Other, err.to_string())
+}
+
+impl std::io::Read for File {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let file_size = self.size().map_err(map_to_io_error)?;
+        let remaining_len = file_size.saturating_sub(self.pos);
+
+        let amt = std::cmp::min(buf.len(), remaining_len);
+        let selection = hdf5::Selection::new(self.pos..self.pos + amt);
+
+        let data = self
+            .hdf5_ds
+            .read_slice_1d::<u8, _>(selection)
+            .map_err(map_to_io_error)?;
+
+        let data_slice = data
+            .as_slice()
+            .ok_or(map_to_io_error("Failed to read data."))?;
+        #[allow(clippy::indexing_slicing)]
+        buf[..amt].copy_from_slice(data_slice);
+
+        self.pos = self.pos.saturating_add(amt);
+        Ok(amt)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use temp_dir::TempDir;
+
+    use super::*;
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn file_test() {
+        let tmp_dir = TempDir::new().expect("Failed to create temp dir.");
+
+        let package_name = tmp_dir.child("test.hdf5");
+        let package = hdf5::File::create(package_name).expect("Failed to create a new package.");
+        let group = package
+            .as_group()
+            .expect("Failed to get a root group from package.");
+
+        let file_name = "test.txt";
+        let file_content = b"test1";
+
+        assert!(group.dataset(file_name).is_err());
+        let mut file =
+            File::create(&group, file_name, file_content).expect("Failed to create a new file.");
+        assert!(group.dataset(file_name).is_ok());
+
+        let mut buffer = Vec::new();
+        file.read_to_end(&mut buffer)
+            .expect("Failed to read from file.");
+        assert_eq!(buffer, file_content);
+
+        // let dataspace = file.0.space().unwrap().extents().unwrap();
+        // println!("{}", dataspace.is_resizable());
+
+        // let writer = file.hdf5_ds.as_writer();
+        // writer.write(b"test_2").expect("Failed to write to file.");
+
+        // let mut buffer = Vec::new();
+        // file.reader()
+        //     .expect("Failed to read from file.")
+        //     .read_to_end(&mut buffer)
+        //     .expect("Failed to read from file.");
+        // assert_eq!(buffer, b"test2");
     }
 }

--- a/hermes/bin/src/hdf5/file.rs
+++ b/hermes/bin/src/hdf5/file.rs
@@ -38,8 +38,7 @@ impl File {
 
     /// Return file size.
     fn size(&self) -> anyhow::Result<usize> {
-        let dataspace = self.hdf5_ds.space()?;
-        let shape = dataspace.shape();
+        let shape = self.hdf5_ds.space()?.shape();
         let size = shape
             .first()
             .ok_or(anyhow::anyhow!("Failed to get file size.",))?;

--- a/hermes/bin/src/packaging/app/mod.rs
+++ b/hermes/bin/src/packaging/app/mod.rs
@@ -205,7 +205,7 @@ impl ApplicationPackage {
         self.0
             .get_file(Self::METADATA_FILE.into())
             .map_err(|_| MissingPackageFileError(Self::METADATA_FILE.to_string()))
-            .map(|file| Metadata::<Self>::from_reader(file.reader()?))?
+            .map(Metadata::<Self>::from_reader)?
     }
 
     /// Get author `Signature` object from package.
@@ -215,7 +215,7 @@ impl ApplicationPackage {
         self.0
             .get_file(Self::AUTHOR_COSE_FILE.into())
             .ok()
-            .map(|file| Signature::<author_payload::SignaturePayload>::from_reader(file.reader()?))
+            .map(Signature::<author_payload::SignaturePayload>::from_reader)
             .transpose()
     }
 

--- a/hermes/bin/src/packaging/wasm_module/mod.rs
+++ b/hermes/bin/src/packaging/wasm_module/mod.rs
@@ -188,7 +188,7 @@ impl WasmModulePackage {
         self.0
             .get_file(Self::METADATA_FILE.into())
             .map_err(|_| MissingPackageFileError(Self::METADATA_FILE.to_string()))
-            .map(|file| Metadata::<Self>::from_reader(file.reader()?))?
+            .map(Metadata::<Self>::from_reader)?
     }
 
     /// Get `wasm::module::Module` object from package.
@@ -196,7 +196,7 @@ impl WasmModulePackage {
         self.0
             .get_file(Self::COMPONENT_FILE.into())
             .map_err(|_| MissingPackageFileError(Self::METADATA_FILE.to_string()))
-            .map(|file| wasm::module::Module::from_reader(file.reader()?))?
+            .map(wasm::module::Module::from_reader)?
     }
 
     /// Get `Signature` object from package.
@@ -204,7 +204,7 @@ impl WasmModulePackage {
         self.0
             .get_file(Self::AUTHOR_COSE_FILE.into())
             .ok()
-            .map(|file| Signature::<SignaturePayload>::from_reader(file.reader()?))
+            .map(Signature::<SignaturePayload>::from_reader)
             .transpose()
     }
 
@@ -213,7 +213,7 @@ impl WasmModulePackage {
         self.0
             .get_file(Self::CONFIG_SCHEMA_FILE.into())
             .ok()
-            .map(|file| ConfigSchema::from_reader(file.reader()?))
+            .map(ConfigSchema::from_reader)
             .transpose()
     }
 
@@ -227,7 +227,7 @@ impl WasmModulePackage {
         };
 
         if let Ok(file) = self.0.get_file(Self::CONFIG_FILE.into()) {
-            let config_file = Config::from_reader(file.reader()?, config_schema.validator())?;
+            let config_file = Config::from_reader(file, config_schema.validator())?;
             Ok((Some(config_file), Some(config_schema)))
         } else {
             Ok((None, Some(config_schema)))
@@ -239,7 +239,7 @@ impl WasmModulePackage {
         self.0
             .get_file(Self::SETTINGS_SCHEMA_FILE.into())
             .ok()
-            .map(|file| SettingsSchema::from_reader(file.reader()?))
+            .map(SettingsSchema::from_reader)
             .transpose()
     }
 


### PR DESCRIPTION
# Description

Implemented `std::io::Read`, `std::io::Write`, `std::io::Seek` for `hdf5::File`.
Removed redundant `hdf5::File::reader` function.

## Related Issue(s)

#292
