### PR TITLE
fix: VFS hdf5 file corruption, mounting app package content

### DIFF
--- a/hermes/bin/src/hdf5/dir.rs
+++ b/hermes/bin/src/hdf5/dir.rs
@@ -140,7 +140,6 @@ impl Dir {
     }
 
     /// Remove directory by the provided path.
-    #[allow(dead_code)]
     pub(crate) fn remove_dir(&self, mut path: Path) -> anyhow::Result<()> {
         let dir_name = path.pop_elem();
         let dir = self.get_dir(&path)?;

--- a/hermes/bin/src/hdf5/file.rs
+++ b/hermes/bin/src/hdf5/file.rs
@@ -107,6 +107,8 @@ impl std::io::Write for File {
     }
 
     fn flush(&mut self) -> std::io::Result<()> {
+        let package = self.hdf5_ds.file().map_err(map_to_io_error)?;
+        package.flush().map_err(map_to_io_error)?;
         Ok(())
     }
 }

--- a/hermes/bin/src/vfs/bootstrap.rs
+++ b/hermes/bin/src/vfs/bootstrap.rs
@@ -187,7 +187,7 @@ mod tests {
         let dir = new_dir.get_dir(&dir_name.into()).unwrap();
         assert!(dir.get_file(file_name.into()).is_ok());
 
-        // open existing vfs instance from disk with the same boostrapping configuration
+        // open existing vfs instance from disk with the same bootstrapping configuration
 
         drop(vfs);
         let mut bootstrapper = VfsBootstrapper::new(tmp_dir.path(), vfs_name.clone());

--- a/hermes/bin/src/vfs/bootstrap.rs
+++ b/hermes/bin/src/vfs/bootstrap.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use hdf5 as hdf5_lib;
 
 use super::Vfs;
-use crate::hdf5::{self as hermes_hdf5};
+use crate::hdf5 as hermes_hdf5;
 
 /// Hermes virtual file system builder.
 pub(crate) struct VfsBootstrapper {

--- a/hermes/bin/src/vfs/bootstrap.rs
+++ b/hermes/bin/src/vfs/bootstrap.rs
@@ -13,116 +13,51 @@ pub(crate) struct VfsBootstrapper {
     vfs_dir_path: PathBuf,
     /// VFS file name.
     vfs_file_name: String,
-    /// HDF5 mounted content.
-    hdf5_mount: Hdf5Mount,
-}
-
-/// HDF5 mounted content struct.
-#[derive(Default)]
-pub(crate) struct Hdf5Mount {
-    /// Mounted files to the `/` directory
-    root_files: Vec<hermes_hdf5::File>,
-    /// Mounted content to `lib` directory
-    to_lib: Vec<Hdf5MountToLib>,
-    /// Mounted `share` directory.
-    share: Option<hermes_hdf5::Dir>,
-    /// Mounted `www` directory.
-    www: Option<hermes_hdf5::Dir>,
-}
-/// HDF5 mounted content to `lib` directory struct.
-pub(crate) struct Hdf5MountToLib {
-    /// Module's directory name
-    dir_name: String,
     /// Mounted module's files
-    files: Vec<hermes_hdf5::File>,
+    mounted_files: Vec<(hermes_hdf5::Path, hermes_hdf5::File)>,
     /// Mounted module's directories.
-    dirs: Vec<hermes_hdf5::Dir>,
-}
-
-impl Hdf5Mount {
-    /// Add a mounted root file
-    pub(crate) fn with_root_file(&mut self, root_file: hermes_hdf5::File) {
-        self.root_files.push(root_file);
-    }
-
-    /// Add a mounted module's content
-    pub(crate) fn with_to_lib(&mut self, to_lib: Hdf5MountToLib) {
-        self.to_lib.push(to_lib);
-    }
-
-    /// Add a mounted share directory.
-    pub(crate) fn with_share_dir(&mut self, share: hermes_hdf5::Dir) {
-        self.share = Some(share);
-    }
-
-    /// Add a mounted www directory.
-    pub(crate) fn with_www_dir(&mut self, www: hermes_hdf5::Dir) {
-        self.www = Some(www);
-    }
-}
-
-impl Hdf5MountToLib {
-    /// Create a `Hdf5MountToLib`
-    pub(crate) fn new(dir_name: String) -> Self {
-        Self {
-            dir_name,
-            files: Vec::new(),
-            dirs: Vec::new(),
-        }
-    }
-
-    /// Add a mounted file
-    pub(crate) fn with_file(&mut self, file: hermes_hdf5::File) {
-        self.files.push(file);
-    }
-
-    /// Add a mounted dir
-    pub(crate) fn with_dir(&mut self, dir: hermes_hdf5::Dir) {
-        self.dirs.push(dir);
-    }
+    mounted_dirs: Vec<(hermes_hdf5::Path, hermes_hdf5::Dir)>,
+    /// HDF5 directories to create
+    dirs_to_create: Vec<hermes_hdf5::Path>,
 }
 
 impl VfsBootstrapper {
-    /// Virtual file system `etc` directory name.
-    const ETC_DIR: &'static str = "etc";
-    /// Virtual file system file extension.
-    const FILE_EXTENSION: &'static str = "hfs";
-    /// Virtual file system `lib` directory name.
-    const LIB_DIR: &'static str = "lib";
-    /// Virtual file system `srv` directory name.
-    const SRV_DIR: &'static str = "srv";
-    /// Virtual file system `srv/share` directory name.
-    const SRV_SHARE_DIR: &'static str = "srv/share";
-    /// Virtual file system `srv/www` directory name.
-    const SRV_WWW_DIR: &'static str = "srv/www";
-    /// Virtual file system `tmp` directory name.
-    const TMP_DIR: &'static str = "tmp";
-    /// Virtual file system `usr` directory name.
-    const USR_DIR: &'static str = "usr";
-    /// Virtual file system `usr/lib` directory name.
-    const USR_LIB_DIR: &'static str = "usr/lib";
-
     /// Create a new `VfsBootstrapper` instance.
     pub(crate) fn new<P: AsRef<std::path::Path>>(vfs_dir_path: P, vfs_file_name: String) -> Self {
         Self {
             vfs_dir_path: vfs_dir_path.as_ref().to_path_buf(),
             vfs_file_name,
-            hdf5_mount: Hdf5Mount::default(),
+            mounted_files: Vec::new(),
+            mounted_dirs: Vec::new(),
+            dirs_to_create: Vec::new(),
         }
     }
 
-    /// Set `Hdf5Mount` object
-    pub(crate) fn set_hdf5_mount(&mut self, hdf5_mount: Hdf5Mount) {
-        self.hdf5_mount = hdf5_mount;
+    /// Add a `Dir` creation by the provided path during bootstrapping
+    #[allow(dead_code)]
+    pub(crate) fn with_dir_to_create(&mut self, path: hermes_hdf5::Path) {
+        self.dirs_to_create.push(path);
+    }
+
+    /// Add a mounted file
+    #[allow(dead_code)]
+    pub(crate) fn with_mounted_file(&mut self, to: hermes_hdf5::Path, file: hermes_hdf5::File) {
+        self.mounted_files.push((to, file));
+    }
+
+    /// Add a mounted dir
+    #[allow(dead_code)]
+    pub(crate) fn with_mounted_dir(&mut self, to: hermes_hdf5::Path, dir: hermes_hdf5::Dir) {
+        self.mounted_dirs.push((to, dir));
     }
 
     /// Bootstrap the virtual file system from the provided configuration.
     pub(crate) fn bootstrap(self) -> anyhow::Result<Vfs> {
         let mut vfs_file_path = self.vfs_dir_path.join(self.vfs_file_name.as_str());
-        vfs_file_path.set_extension(Self::FILE_EXTENSION);
+        vfs_file_path.set_extension(Vfs::FILE_EXTENSION);
 
-        let (root, _hdf5_file) = if let Ok(hdf5_file) = hdf5_lib::File::open_rw(&vfs_file_path) {
-            (hermes_hdf5::Dir::new(hdf5_file.as_group()?), hdf5_file)
+        let root = if let Ok(hdf5_file) = hdf5_lib::File::open_rw(&vfs_file_path) {
+            hermes_hdf5::Dir::new(hdf5_file.as_group()?)
         } else {
             let hdf5_file = hdf5_lib::File::create(&vfs_file_path).map_err(|_| {
                 anyhow::anyhow!(
@@ -132,48 +67,48 @@ impl VfsBootstrapper {
             })?;
             let root = hermes_hdf5::Dir::new(hdf5_file.as_group()?);
             Self::setup_hdf5_vfs_structure(&root)?;
-            (root, hdf5_file)
+            root
         };
 
-        Self::mount_hdf5_content(&root, &self.hdf5_mount)?;
+        Self::mount_hdf5_content(
+            &root,
+            self.dirs_to_create,
+            &self.mounted_files,
+            &self.mounted_dirs,
+        )?;
 
         Ok(Vfs { root })
     }
 
     /// Setup hdf5 VFS directories structure.
     fn setup_hdf5_vfs_structure(root: &hermes_hdf5::Dir) -> anyhow::Result<()> {
-        root.create_dir(Self::TMP_DIR.into())?;
-        root.create_dir(Self::ETC_DIR.into())?;
-        root.create_dir(Self::SRV_DIR.into())?;
-        root.create_dir(Self::USR_DIR.into())?;
-        root.create_dir(Self::USR_LIB_DIR.into())?;
-        root.create_dir(Self::LIB_DIR.into())?;
+        root.create_dir(Vfs::TMP_DIR.into())?;
+        root.create_dir(Vfs::ETC_DIR.into())?;
+        root.create_dir(Vfs::SRV_DIR.into())?;
+        root.create_dir(Vfs::USR_DIR.into())?;
+        root.create_dir(Vfs::USR_LIB_DIR.into())?;
+        root.create_dir(Vfs::LIB_DIR.into())?;
 
         Ok(())
     }
 
     /// Mount hdf5 content to the VFS.
-    fn mount_hdf5_content(root: &hermes_hdf5::Dir, mount: &Hdf5Mount) -> anyhow::Result<()> {
-        for root_file in &mount.root_files {
-            root.mount_file(root_file, root_file.name().into())?;
+    fn mount_hdf5_content(
+        root: &hermes_hdf5::Dir, dirs_to_create: Vec<hermes_hdf5::Path>,
+        mounted_files: &Vec<(hermes_hdf5::Path, hermes_hdf5::File)>,
+        mounted_dirs: &Vec<(hermes_hdf5::Path, hermes_hdf5::Dir)>,
+    ) -> anyhow::Result<()> {
+        for dir_to_create in dirs_to_create {
+            root.create_dir(dir_to_create)?;
         }
-        for to_lib in &mount.to_lib {
-            let lib_dir = root.get_dir(&Self::LIB_DIR.into())?;
-            let to_lib_dir = lib_dir.create_dir(to_lib.dir_name.as_str().into())?;
+        for (to, file) in mounted_files {
+            let to_dir = root.get_dir(to)?;
+            to_dir.mount_file(file, file.name().into())?;
+        }
 
-            for file in &to_lib.files {
-                to_lib_dir.mount_file(file, file.name().into())?;
-            }
-
-            for dir in &to_lib.dirs {
-                to_lib_dir.mount_dir(dir, dir.name().into())?;
-            }
-        }
-        if let Some(www) = mount.www.as_ref() {
-            root.mount_dir(www, Self::SRV_WWW_DIR.into())?;
-        }
-        if let Some(share) = mount.share.as_ref() {
-            root.mount_dir(share, Self::SRV_SHARE_DIR.into())?;
+        for (to, dir) in mounted_dirs {
+            let to_dir = root.get_dir(to)?;
+            to_dir.mount_dir(dir, dir.name().into())?;
         }
         Ok(())
     }
@@ -197,23 +132,12 @@ mod tests {
             .unwrap();
 
         // check VFS hdf5 directories structure
-        assert!(vfs.root.get_dir(&VfsBootstrapper::TMP_DIR.into()).is_ok());
-        assert!(vfs.root.get_dir(&VfsBootstrapper::ETC_DIR.into()).is_ok());
-        assert!(vfs.root.get_dir(&VfsBootstrapper::SRV_DIR.into()).is_ok());
-        assert!(vfs
-            .root
-            .get_dir(&VfsBootstrapper::SRV_WWW_DIR.into())
-            .is_err());
-        assert!(vfs
-            .root
-            .get_dir(&VfsBootstrapper::SRV_SHARE_DIR.into())
-            .is_err());
-        assert!(vfs.root.get_dir(&VfsBootstrapper::USR_DIR.into()).is_ok());
-        assert!(vfs
-            .root
-            .get_dir(&VfsBootstrapper::USR_LIB_DIR.into())
-            .is_ok());
-        assert!(vfs.root.get_dir(&VfsBootstrapper::LIB_DIR.into()).is_ok());
+        assert!(vfs.root.get_dir(&Vfs::TMP_DIR.into()).is_ok());
+        assert!(vfs.root.get_dir(&Vfs::ETC_DIR.into()).is_ok());
+        assert!(vfs.root.get_dir(&Vfs::SRV_DIR.into()).is_ok());
+        assert!(vfs.root.get_dir(&Vfs::USR_DIR.into()).is_ok());
+        assert!(vfs.root.get_dir(&Vfs::USR_LIB_DIR.into()).is_ok());
+        assert!(vfs.root.get_dir(&Vfs::LIB_DIR.into()).is_ok());
 
         drop(vfs);
         let _vfs = VfsBootstrapper::new(tmp_dir.path(), vfs_name.clone())
@@ -235,41 +159,31 @@ mod tests {
         let file_name = "file.txt";
         let file = dir1.create_file(file_name.into()).unwrap();
 
-        let mut mount = Hdf5Mount::default();
-        mount.with_root_file(file.clone());
-        mount.with_www_dir(dir1.clone());
-        mount.with_share_dir(dir1.clone());
-
-        let module_name = "module_1";
-        let mut to_lib = Hdf5MountToLib::new(module_name.to_string());
-        to_lib.with_file(file);
-        to_lib.with_dir(dir1);
-
-        mount.with_to_lib(to_lib);
-
         let vfs_name = "test_vfs".to_string();
         let mut bootstrapper = VfsBootstrapper::new(tmp_dir.path(), vfs_name);
-        bootstrapper.set_hdf5_mount(mount);
+
+        bootstrapper.with_mounted_file("/".into(), file.clone());
+
+        let dir_to_create_name = "new_dir";
+        bootstrapper.with_dir_to_create(format!("{}/{dir_to_create_name}", Vfs::LIB_DIR).into());
+        bootstrapper.with_mounted_file(
+            format!("{}/{dir_to_create_name}", Vfs::LIB_DIR).into(),
+            file.clone(),
+        );
+        bootstrapper.with_mounted_dir(
+            format!("{}/{dir_to_create_name}", Vfs::LIB_DIR).into(),
+            dir1.clone(),
+        );
 
         let vfs = bootstrapper.bootstrap().unwrap();
 
         // check VFS hdf5 directories structure
         assert!(vfs.root.get_file(file_name.into()).is_ok());
-        let www_dir = vfs
-            .root
-            .get_dir(&VfsBootstrapper::SRV_WWW_DIR.into())
-            .unwrap();
-        assert!(www_dir.get_file(file_name.into()).is_ok());
-        let share_dir = vfs
-            .root
-            .get_dir(&VfsBootstrapper::SRV_SHARE_DIR.into())
-            .unwrap();
-        assert!(share_dir.get_file(file_name.into()).is_ok());
 
-        let lib_dir = vfs.root.get_dir(&VfsBootstrapper::LIB_DIR.into()).unwrap();
-        let module_dir = lib_dir.get_dir(&module_name.into()).unwrap();
-        assert!(module_dir.get_file(file_name.into()).is_ok());
-        let share_dir = module_dir.get_dir(&dir_name.into()).unwrap();
-        assert!(share_dir.get_file(file_name.into()).is_ok());
+        let lib_dir = vfs.root.get_dir(&Vfs::LIB_DIR.into()).unwrap();
+        let new_dir = lib_dir.get_dir(&dir_to_create_name.into()).unwrap();
+        assert!(new_dir.get_file(file_name.into()).is_ok());
+        let dir = new_dir.get_dir(&dir_name.into()).unwrap();
+        assert!(dir.get_file(file_name.into()).is_ok());
     }
 }

--- a/hermes/bin/src/vfs/mod.rs
+++ b/hermes/bin/src/vfs/mod.rs
@@ -12,7 +12,6 @@ use crate::hdf5::{self as hermes_hdf5, Path};
 #[derive(Clone, Debug)]
 pub(crate) struct Vfs {
     /// HDF5 root directory of the virtual file system.
-    #[allow(dead_code)]
     root: hermes_hdf5::Dir,
     // TODO: add permissions RWX
 }


### PR DESCRIPTION
# Description

Fixed issues with the hdf5 file corruption during the hermes run.
To solve it was added flushing calls after every update of the hdf5 state.
Also fixed an issue with the mounting files during the bootstrap process.


## Related Issue(s)

#308 

## Description of Changes

- Refactored `VfsBoostrapper` struct, changed mount interface.
- Refactored `Vfs` struct, updated `read` and `write` interface.
- Added flushing calls on most of the methods of the `hdf5::Dir` struct.
- Added actual implementation of the `std::io::Write::flush` trait function for the `hdf5::File` struct. 