### PR TITLE
test(chain-follower): Add unit tests to the overall Chain Follower module

### DIFF
--- a/hermes/crates/cardano-chain-follower/src/data_index.rs
+++ b/hermes/crates/cardano-chain-follower/src/data_index.rs
@@ -417,3 +417,39 @@ pub(crate) fn background_index_blocks_and_transactions(
         mithril_valid
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use minicbor::decode;
+
+    #[test]
+    fn test_serialize_value_simple() {
+        let slot_no = 12345;
+        let txn_offset = 678;
+        
+        let serialized = serialize_value(slot_no, txn_offset);
+        
+        assert!(!serialized.is_empty(), "Serialized output must not be empty");
+
+        let decoded: HashIndex = decode(&serialized).expect("Failed to decode serialized bytes");
+
+        assert_eq!(decoded.slot_no, slot_no);
+        assert_eq!(decoded.txn_offset, txn_offset);
+    }
+
+    #[test]
+    fn test_deserialize_value_simple() {
+        let slot_no = 12345u64;
+        let txn_offset = 678u16;
+
+        let mut value = [0u8; 10];
+        value[0..8].copy_from_slice(&slot_no.to_be_bytes());
+        value[8..10].copy_from_slice(&txn_offset.to_be_bytes());
+
+        let (deserialized_slot_no, deserialized_txn_offset) = deserialize_value(value);
+
+        assert_eq!(deserialized_slot_no, slot_no);
+        assert_eq!(deserialized_txn_offset, txn_offset);
+    }
+}

--- a/hermes/crates/cardano-chain-follower/src/mithril_snapshot_config.rs
+++ b/hermes/crates/cardano-chain-follower/src/mithril_snapshot_config.rs
@@ -497,6 +497,49 @@ fn is_hex(s: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    // use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn test_default_for() {
+        let network = Network::Preprod;
+        let config = MithrilSnapshotConfig::default_for(network);
+
+        assert_eq!(config.chain, network);
+        assert_eq!(config.path, network.default_mithril_path());
+        assert_eq!(config.aggregator_url, network.default_mithril_aggregator());
+        assert_eq!(config.genesis_key, network.default_mithril_genesis_key());
+    }
+
+    #[tokio::test]
+    async fn test_dl_path() {
+        let network = Network::Preprod;
+        let config = MithrilSnapshotConfig::default_for(network);
+        let expected_path = config.path.join("dl");
+
+        assert_eq!(config.dl_path(), expected_path);
+    }
+
+    #[tokio::test]
+    async fn test_validate_genesis_vkey() {
+        let config = MithrilSnapshotConfig {
+            chain: Network::Preprod,
+            path: PathBuf::new(),
+            aggregator_url: String::new(),
+            genesis_key: "1234abcd".to_string(),
+        };
+
+        assert!(config.validate_genesis_vkey().is_ok());
+
+        let invalid_config = MithrilSnapshotConfig {
+            chain: Network::Preprod,
+            path: PathBuf::new(),
+            aggregator_url: String::new(),
+            genesis_key: "1234abcz".to_string(),
+        };
+
+        assert!(invalid_config.validate_genesis_vkey().is_err());
+    }
 
     // use std::path::Path;
     //

--- a/hermes/crates/cardano-chain-follower/src/network.rs
+++ b/hermes/crates/cardano-chain-follower/src/network.rs
@@ -202,3 +202,23 @@ impl From<Network> for u64 {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Ok;
+
+    use super::*;
+
+    #[test]
+    fn test_from_str() -> anyhow::Result<()> {
+        let mainnet = Network::from_str("mainnet")?;
+        let preprod = Network::from_str("preprod")?;
+        let preview = Network::from_str("preview")?;
+
+        assert_eq!(mainnet, Network::Mainnet);
+        assert_eq!(preprod, Network::Preprod);
+        assert_eq!(preview, Network::Preview);
+        
+        Ok(())
+    }
+}

--- a/hermes/crates/cardano-chain-follower/src/stats.rs
+++ b/hermes/crates/cardano-chain-follower/src/stats.rs
@@ -665,17 +665,6 @@ mod tests {
     use chrono::Utc;
 
     #[test]
-    fn test_mithril_default() {
-        let mithril = Mithril::default();
-        assert_eq!(mithril.updates, 0);
-        assert_eq!(mithril.tip, 0);
-        assert_eq!(mithril.dl_failures, 0);
-        assert_eq!(mithril.extract_failures, 0);
-        assert_eq!(mithril.validate_failures, 0);
-        assert_eq!(mithril.invalid_blocks, 0);
-    }
-
-    #[test]
     fn test_mithril_reset() {
         let mut mithril = Mithril {
             updates: 10,
@@ -694,32 +683,6 @@ mod tests {
     }
 
     #[test]
-    fn test_follower_default() {
-        let follower = Follower::default();
-        assert_eq!(follower.id, 0);
-        assert_eq!(follower.start, 0);
-        assert_eq!(follower.current, 0);
-        assert_eq!(follower.end, 0);
-    }
-
-    #[test]
-    fn test_live_default() {
-        let live = Live::default();
-        assert_eq!(live.backfill_size, 0);
-        assert_eq!(live.backfill_failures, 0);
-        assert_eq!(live.blocks, 0);
-        assert_eq!(live.head_slot, 0);
-        assert_eq!(live.tip, 0);
-        assert_eq!(live.reconnects, 0);
-        assert_eq!(live.new_blocks, 0);
-        assert_eq!(live.invalid_blocks, 0);
-        assert!(live.sync_end.is_none());
-        assert!(live.backfill_start.is_none());
-        assert!(live.backfill_end.is_none());
-        assert!(live.backfill_failure_time.is_none());
-    }
-
-    #[test]
     fn test_live_reset() {
         let mut live = Live {
             new_blocks: 10,
@@ -731,13 +694,6 @@ mod tests {
         assert_eq!(live.new_blocks, 0);
         assert_eq!(live.reconnects, 0);
         assert_eq!(live.invalid_blocks, 0);
-    }
-
-    #[test]
-    fn test_statistics_default() {
-        let stats = Statistics::default();
-        assert_eq!(stats.live.blocks, 0);
-        assert_eq!(stats.mithril.updates, 0);
     }
 
     #[test]

--- a/hermes/crates/cardano-chain-follower/src/stats.rs
+++ b/hermes/crates/cardano-chain-follower/src/stats.rs
@@ -662,7 +662,7 @@ pub(crate) fn rollback(chain: Network, rollback: RollbackType, depth: u64) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    // use chrono::{TimeZone, Utc};
+    use chrono::Utc;
 
     #[test]
     fn test_mithril_default() {


### PR DESCRIPTION
# Description

The module already has some tests to `multi_era_block.rs` and `snapshot_id.rs`. But the rest of the module still doesn't have the test yet. So we need to create additional unit tests that don't interact with networking stuffs.

## Related Issue(s)

Closes #305 

## Description of Changes

Added unit tests to non-environmental interactive tests `data_index.rs`, `follow.rs`, `mithril_snapshot_config.rs`, `network.rs`, and `stats.rs`.

## Please confirm the following checks

* [ ] My code follows the style guidelines of this project
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
