### PR TITLE
feat: VFS permissions handling

### DIFF
--- a/hermes/bin/src/app.rs
+++ b/hermes/bin/src/app.rs
@@ -1,6 +1,6 @@
 //! Hermes app implementation.
 
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 use crate::{
     vfs::Vfs,
@@ -29,8 +29,7 @@ pub(crate) struct HermesApp {
     indexed_modules: HashMap<ModuleId, Module>,
 
     /// App `Vfs` instance
-    #[allow(dead_code)]
-    vfs: Vfs,
+    vfs: Arc<Vfs>,
 }
 
 impl HermesApp {
@@ -43,7 +42,7 @@ impl HermesApp {
         Self {
             app_name,
             indexed_modules,
-            vfs,
+            vfs: Arc::new(vfs),
         }
     }
 
@@ -53,8 +52,8 @@ impl HermesApp {
     }
 
     /// Get vfs
-    pub(crate) fn vfs(&self) -> &Vfs {
-        &self.vfs
+    pub(crate) fn vfs(&self) -> Arc<Vfs> {
+        self.vfs.clone()
     }
 
     /// Get indexed modules

--- a/hermes/bin/src/cli/app/package.rs
+++ b/hermes/bin/src/cli/app/package.rs
@@ -6,7 +6,7 @@ use chrono::Utc;
 use clap::Args;
 use console::Emoji;
 
-use crate::packaging::app::{manifest::Manifest, ApplicationPackage};
+use crate::packaging::app::{ApplicationPackage, Manifest};
 
 /// Hermes application packaging
 #[derive(Args)]

--- a/hermes/bin/src/cli/run.rs
+++ b/hermes/bin/src/cli/run.rs
@@ -47,7 +47,7 @@ impl Run {
         println!("{} Bootstrapping virtual filesystem", Emoji::new("🗄️", ""));
         let hermes_home_dir = Cli::hermes_home()?;
         let mut bootstrapper = VfsBootstrapper::new(hermes_home_dir, app_name.clone());
-        package.bootstrap_vfs(&mut bootstrapper)?;
+        package.mount_to_vfs(&mut bootstrapper)?;
         let vfs = bootstrapper.bootstrap()?;
 
         println!("{} Running application {app_name}\n", Emoji::new("🚀", ""),);

--- a/hermes/bin/src/cli/run.rs
+++ b/hermes/bin/src/cli/run.rs
@@ -8,13 +8,12 @@ use console::Emoji;
 use crate::{
     app::{HermesApp, HermesAppName},
     cli::Cli,
-    hdf5::Path,
     packaging::{
         app::ApplicationPackage,
         sign::certificate::{self, Certificate},
     },
     reactor::HermesReactor,
-    vfs::{Vfs, VfsBootstrapper},
+    vfs::VfsBootstrapper,
 };
 
 /// Run cli command
@@ -46,7 +45,10 @@ impl Run {
         let app_name = package.get_metadata()?.get_name()?;
 
         println!("{} Bootstrapping virtual filesystem", Emoji::new("🗄️", ""));
-        let vfs = bootstrap_vfs(app_name.clone(), &package)?;
+        let hermes_home_dir = Cli::hermes_home()?;
+        let mut bootstrapper = VfsBootstrapper::new(hermes_home_dir, app_name.clone());
+        package.bootstrap_vfs(&mut bootstrapper)?;
+        let vfs = bootstrapper.bootstrap()?;
 
         println!("{} Running application {app_name}\n", Emoji::new("🚀", ""),);
         let mut modules = Vec::new();
@@ -61,50 +63,4 @@ impl Run {
 
         Ok(())
     }
-}
-
-/// Bootstrap Hermes virtual filesystem
-fn bootstrap_vfs(app_name: String, package: &ApplicationPackage) -> anyhow::Result<Vfs> {
-    let hermes_home_dir = Cli::hermes_home()?;
-    let mut bootstrapper = VfsBootstrapper::new(hermes_home_dir, app_name);
-
-    let root_path = Path::default();
-    bootstrapper.with_mounted_file(root_path.clone(), package.get_icon_file()?);
-    bootstrapper.with_mounted_file(root_path.clone(), package.get_metadata_file()?);
-    if let Some(share_dir) = package.get_share_dir() {
-        bootstrapper.with_mounted_dir(root_path.clone(), share_dir);
-    }
-    if let Some(www_dir) = package.get_www_dir() {
-        bootstrapper.with_mounted_dir(root_path.clone(), www_dir);
-    }
-
-    for module_info in package.get_modules()? {
-        let lib_module_dir_path: Path =
-            format!("{}/{}", Vfs::LIB_DIR, module_info.get_name()).into();
-        bootstrapper.with_dir_to_create(lib_module_dir_path.clone());
-
-        bootstrapper.with_mounted_file(
-            lib_module_dir_path.clone(),
-            module_info.get_metadata_file()?,
-        );
-        bootstrapper.with_mounted_file(
-            lib_module_dir_path.clone(),
-            module_info.get_component_file()?,
-        );
-        if let Some(config_schema) = module_info.get_config_schema_file() {
-            bootstrapper.with_mounted_file(lib_module_dir_path.clone(), config_schema);
-        }
-        if let Some(config) = module_info.get_config_file() {
-            bootstrapper.with_mounted_file(lib_module_dir_path.clone(), config);
-        }
-        if let Some(settings_schema) = module_info.get_settings_schema_file() {
-            bootstrapper.with_mounted_file(lib_module_dir_path.clone(), settings_schema);
-        }
-        if let Some(share_dir) = module_info.get_share() {
-            bootstrapper.with_mounted_dir(lib_module_dir_path.clone(), share_dir);
-        }
-    }
-
-    let vfs = bootstrapper.bootstrap()?;
-    Ok(vfs)
 }

--- a/hermes/bin/src/event/queue.rs
+++ b/hermes/bin/src/event/queue.rs
@@ -43,7 +43,7 @@ pub(crate) struct NotInitializedError;
 pub(crate) struct EventLoopPanicsError;
 
 /// Hermes event execution context
-type ExecutionContext<'a> = (&'a HermesAppName, &'a ModuleId, &'a Module, &'a Vfs);
+type ExecutionContext<'a> = (&'a HermesAppName, &'a ModuleId, &'a Module, Arc<Vfs>);
 
 /// Hermes event queue.
 /// It is a singleton struct.
@@ -158,7 +158,7 @@ pub(crate) fn send(event: HermesEvent) -> anyhow::Result<()> {
 /// Execute a hermes event on the provided module and all necessary info.
 pub(crate) fn event_dispatch(
     app_name: HermesAppName, module_id: ModuleId, module: &Module, event: &dyn HermesEventPayload,
-    vfs: Vfs,
+    vfs: Arc<Vfs>,
 ) {
     let runtime_context = HermesRuntimeContext::new(
         app_name,

--- a/hermes/bin/src/hdf5/path.rs
+++ b/hermes/bin/src/hdf5/path.rs
@@ -8,7 +8,6 @@ pub(crate) struct Path(Vec<String>);
 
 impl Path {
     /// Create new `PackagePath` from path components.
-    #[allow(dead_code)]
     pub(crate) fn new(path_components: Vec<String>) -> Self {
         Self(path_components)
     }
@@ -16,7 +15,7 @@ impl Path {
     /// Create new `PackagePath` from str.
     pub(crate) fn from_str(path: &str) -> Self {
         let path_components = path
-            .split('/')
+            .split(&['/', '\\'])
             .map(ToString::to_string)
             .filter(|s| !s.is_empty())
             .collect();
@@ -74,6 +73,7 @@ mod tests {
 
     #[test]
     fn package_path_test() {
+        // with '/' delimiter
         {
             let mut path = Path::from_str("/a/b/c");
             assert_eq!(path.pop_elem(), "c".to_string());
@@ -94,12 +94,37 @@ mod tests {
             assert_eq!(path.pop_elem(), String::new());
         }
         {
-            let mut path = Path::from_str("a");
+            let mut path = Path::from_str("/");
+            assert_eq!(path.pop_elem(), String::new());
+        }
+        // with '\' delimiter
+        {
+            let mut path = Path::from_str(r"\a\b\c");
+            assert_eq!(path.pop_elem(), "c".to_string());
+            assert_eq!(path.pop_elem(), "b".to_string());
             assert_eq!(path.pop_elem(), "a".to_string());
             assert_eq!(path.pop_elem(), String::new());
         }
         {
-            let mut path = Path::from_str("/");
+            let mut path = Path::from_str(r"a\b\c");
+            assert_eq!(path.pop_elem(), "c".to_string());
+            assert_eq!(path.pop_elem(), "b".to_string());
+            assert_eq!(path.pop_elem(), "a".to_string());
+            assert_eq!(path.pop_elem(), String::new());
+        }
+        {
+            let mut path = Path::from_str(r"\a");
+            assert_eq!(path.pop_elem(), "a".to_string());
+            assert_eq!(path.pop_elem(), String::new());
+        }
+        {
+            let mut path = Path::from_str(r"\");
+            assert_eq!(path.pop_elem(), String::new());
+        }
+
+        {
+            let mut path = Path::from_str("a");
+            assert_eq!(path.pop_elem(), "a".to_string());
             assert_eq!(path.pop_elem(), String::new());
         }
         {

--- a/hermes/bin/src/hdf5/path.rs
+++ b/hermes/bin/src/hdf5/path.rs
@@ -2,24 +2,21 @@
 
 use std::fmt::Display;
 
+use crate::utils::parse_path;
+
 /// Package path.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct Path(Vec<String>);
 
 impl Path {
     /// Create new `PackagePath` from path components.
-    pub(crate) fn new(path_components: Vec<String>) -> Self {
-        Self(path_components)
+    pub(crate) fn new(path_elements: Vec<String>) -> Self {
+        Self(path_elements)
     }
 
     /// Create new `PackagePath` from str.
     pub(crate) fn from_str(path: &str) -> Self {
-        let path_components = path
-            .split(&['/', '\\'])
-            .map(ToString::to_string)
-            .filter(|s| !s.is_empty())
-            .collect();
-        Self(path_components)
+        Self(parse_path(path))
     }
 
     /// Returns an iterator over the path elements.

--- a/hermes/bin/src/lib.rs
+++ b/hermes/bin/src/lib.rs
@@ -15,6 +15,7 @@ pub mod runtime_context;
 pub mod runtime_extensions;
 pub mod vfs;
 pub mod wasm;
+pub mod utils;
 
 #[cfg(feature = "bench")]
 pub use wasm::module::bench::{

--- a/hermes/bin/src/main.rs
+++ b/hermes/bin/src/main.rs
@@ -10,6 +10,7 @@ mod packaging;
 mod reactor;
 mod runtime_context;
 mod runtime_extensions;
+mod utils;
 mod vfs;
 mod wasm;
 

--- a/hermes/bin/src/packaging/app/author_payload.rs
+++ b/hermes/bin/src/packaging/app/author_payload.rs
@@ -1,7 +1,7 @@
 //! A signature payload object for author.cose Hermes application package.
 //! Defined at `https://input-output-hk.github.io/hermes/architecture/08_concepts/hermes_packaging_requirements/app_signatures/#wasm-component-module-signatures`.
 
-use crate::packaging::{
+use super::super::{
     hash::Blake2b256, schema_validation::SchemaValidator, sign::signature::SignaturePayloadEncoding,
 };
 

--- a/hermes/bin/src/packaging/app/manifest.rs
+++ b/hermes/bin/src/packaging/app/manifest.rs
@@ -2,10 +2,8 @@
 
 use std::path::Path;
 
-use crate::{
-    hdf5::resources::{FsResource, ResourceBuilder},
-    packaging::{schema_validation::SchemaValidator, FileError},
-};
+use super::super::{schema_validation::SchemaValidator, FileError};
+use crate::hdf5::resources::{FsResource, ResourceBuilder};
 
 /// Hermes application package manifest.json definition.
 #[derive(Debug, PartialEq, Eq)]

--- a/hermes/bin/src/packaging/app/mod.rs
+++ b/hermes/bin/src/packaging/app/mod.rs
@@ -294,8 +294,8 @@ impl ApplicationPackage {
         self.0.get_dir(&Self::SRV_SHARE_DIR.into()).ok()
     }
 
-    /// bootsrtrap `Vfs` with the `ApplicationPackage` content
-    pub(crate) fn bootstrap_vfs(&self, bootstrapper: &mut VfsBootstrapper) -> anyhow::Result<()> {
+    /// Mount `ApplicationPackage` content to the `Vfs`
+    pub(crate) fn mount_to_vfs(&self, bootstrapper: &mut VfsBootstrapper) -> anyhow::Result<()> {
         let root_path = Path::default();
         bootstrapper.with_mounted_file(root_path.clone(), self.get_icon_file()?);
         bootstrapper.with_mounted_file(root_path.clone(), self.get_metadata_file()?);

--- a/hermes/bin/src/packaging/app/mod.rs
+++ b/hermes/bin/src/packaging/app/mod.rs
@@ -1,31 +1,32 @@
 //! Hermes application package.
 
 mod author_payload;
-pub(crate) mod manifest;
+mod manifest;
 mod module_info;
 
 use chrono::{DateTime, Utc};
 pub(crate) use manifest::{Manifest, ManifestModule};
 pub(crate) use module_info::AppModuleInfo;
 
+use super::{
+    hash::Blake2b256,
+    metadata::{Metadata, MetadataSchema},
+    module::{self, ModulePackage},
+    package::Package,
+    sign::{
+        certificate::Certificate,
+        keys::PrivateKey,
+        signature::{Signature, SignaturePayloadEncoding},
+    },
+    FileError, MissingPackageFileError,
+};
 use crate::{
     errors::Errors,
     hdf5::{
         resources::{BytesResource, ResourceTrait},
         Dir, File, Path,
     },
-    packaging::{
-        hash::Blake2b256,
-        metadata::{Metadata, MetadataSchema},
-        module::{self, ModulePackage},
-        package::Package,
-        sign::{
-            certificate::Certificate,
-            keys::PrivateKey,
-            signature::{Signature, SignaturePayloadEncoding},
-        },
-        FileError, MissingPackageFileError,
-    },
+    vfs::{Vfs, VfsBootstrapper},
 };
 
 /// Hermes application package.
@@ -202,13 +203,13 @@ impl ApplicationPackage {
                 );
 
             let mut usr_module_config_path = usr_module_path.clone();
-            usr_module_config_path.push_elem(ModulePackage::CONFIG_FILE.into());
+            usr_module_config_path.push_elem(Self::MODULE_CONFIG_FILE.into());
             if let Some(config_hash) = self.0.calculate_file_hash(usr_module_config_path)? {
                 signature_payload_module_builder.with_config(config_hash);
             }
 
             let mut usr_module_share_path = usr_module_path.clone();
-            usr_module_share_path.push_elem(ModulePackage::SHARE_DIR.into());
+            usr_module_share_path.push_elem(Self::MODULE_SHARE_DIR.into());
             if let Some(share_hash) = self.0.calculate_dir_hash(&usr_module_share_path)? {
                 signature_payload_module_builder.with_share(share_hash);
             }
@@ -227,14 +228,14 @@ impl ApplicationPackage {
     }
 
     /// Get icon `File` object from package.
-    pub(crate) fn get_icon_file(&self) -> anyhow::Result<File> {
+    pub(super) fn get_icon_file(&self) -> anyhow::Result<File> {
         self.0
             .get_file(Self::ICON_FILE.into())
             .map_err(|_| MissingPackageFileError(Self::ICON_FILE.to_string()).into())
     }
 
     /// Get metadata `File` object from package.
-    pub(crate) fn get_metadata_file(&self) -> anyhow::Result<File> {
+    pub(super) fn get_metadata_file(&self) -> anyhow::Result<File> {
         self.0
             .get_file(Self::METADATA_FILE.into())
             .map_err(|_| MissingPackageFileError(Self::METADATA_FILE.to_string()).into())
@@ -284,13 +285,54 @@ impl ApplicationPackage {
     }
 
     /// Get www dir from package if present.
-    pub(crate) fn get_www_dir(&self) -> Option<Dir> {
+    pub(super) fn get_www_dir(&self) -> Option<Dir> {
         self.0.get_dir(&Self::SRV_WWW_DIR.into()).ok()
     }
 
     /// Get share dir from package if present.
-    pub(crate) fn get_share_dir(&self) -> Option<Dir> {
+    pub(super) fn get_share_dir(&self) -> Option<Dir> {
         self.0.get_dir(&Self::SRV_SHARE_DIR.into()).ok()
+    }
+
+    /// bootsrtrap `Vfs` with the `ApplicationPackage` content
+    pub(crate) fn bootstrap_vfs(&self, bootstrapper: &mut VfsBootstrapper) -> anyhow::Result<()> {
+        let root_path = Path::default();
+        bootstrapper.with_mounted_file(root_path.clone(), self.get_icon_file()?);
+        bootstrapper.with_mounted_file(root_path.clone(), self.get_metadata_file()?);
+        if let Some(share_dir) = self.get_share_dir() {
+            bootstrapper.with_mounted_dir(root_path.clone(), share_dir);
+        }
+        if let Some(www_dir) = self.get_www_dir() {
+            bootstrapper.with_mounted_dir(root_path.clone(), www_dir);
+        }
+
+        for module_info in self.get_modules()? {
+            let lib_module_dir_path: Path =
+                format!("{}/{}", Vfs::LIB_DIR, module_info.get_name()).into();
+            bootstrapper.with_dir_to_create(lib_module_dir_path.clone());
+
+            bootstrapper.with_mounted_file(
+                lib_module_dir_path.clone(),
+                module_info.get_metadata_file()?,
+            );
+            bootstrapper.with_mounted_file(
+                lib_module_dir_path.clone(),
+                module_info.get_component_file()?,
+            );
+            if let Some(config_schema) = module_info.get_config_schema_file() {
+                bootstrapper.with_mounted_file(lib_module_dir_path.clone(), config_schema);
+            }
+            if let Some(config) = module_info.get_config_file() {
+                bootstrapper.with_mounted_file(lib_module_dir_path.clone(), config);
+            }
+            if let Some(settings_schema) = module_info.get_settings_schema_file() {
+                bootstrapper.with_mounted_file(lib_module_dir_path.clone(), settings_schema);
+            }
+            if let Some(share_dir) = module_info.get_share() {
+                bootstrapper.with_mounted_dir(lib_module_dir_path.clone(), share_dir);
+            }
+        }
+        Ok(())
     }
 
     /// Validate and write all content of the `Manifest` to the provided `package`.

--- a/hermes/bin/src/packaging/app/mod.rs
+++ b/hermes/bin/src/packaging/app/mod.rs
@@ -296,63 +296,54 @@ impl ApplicationPackage {
 
     /// Mount `ApplicationPackage` content to the `Vfs`
     pub(crate) fn mount_to_vfs(&self, bootstrapper: &mut VfsBootstrapper) -> anyhow::Result<()> {
-        let root_path = Path::default();
-        bootstrapper.with_mounted_file(
-            root_path.clone(),
-            self.get_icon_file()?,
-            PermissionLevel::Read,
-        );
-        bootstrapper.with_mounted_file(
-            root_path.clone(),
-            self.get_metadata_file()?,
-            PermissionLevel::Read,
-        );
+        let root_path = "/";
+        bootstrapper.with_mounted_file(root_path, self.get_icon_file()?, PermissionLevel::Read);
+        bootstrapper.with_mounted_file(root_path, self.get_metadata_file()?, PermissionLevel::Read);
         if let Some(share_dir) = self.get_share_dir() {
-            bootstrapper.with_mounted_dir(root_path.clone(), share_dir, PermissionLevel::Read);
+            bootstrapper.with_mounted_dir(root_path, share_dir, PermissionLevel::Read);
         }
         if let Some(www_dir) = self.get_www_dir() {
-            bootstrapper.with_mounted_dir(root_path.clone(), www_dir, PermissionLevel::Read);
+            bootstrapper.with_mounted_dir(root_path, www_dir, PermissionLevel::Read);
         }
 
         for module_info in self.get_modules()? {
-            let lib_module_dir_path: Path =
-                format!("{}/{}", Vfs::LIB_DIR, module_info.get_name()).into();
-            bootstrapper.with_dir_to_create(lib_module_dir_path.clone(), PermissionLevel::Read);
+            let lib_module_dir_path = format!("{}/{}", Vfs::LIB_DIR, module_info.get_name());
+            bootstrapper.with_dir_to_create(lib_module_dir_path.as_str(), PermissionLevel::Read);
 
             bootstrapper.with_mounted_file(
-                lib_module_dir_path.clone(),
+                lib_module_dir_path.as_str(),
                 module_info.get_metadata_file()?,
                 PermissionLevel::Read,
             );
             bootstrapper.with_mounted_file(
-                lib_module_dir_path.clone(),
+                lib_module_dir_path.as_str(),
                 module_info.get_component_file()?,
                 PermissionLevel::Read,
             );
             if let Some(config_schema) = module_info.get_config_schema_file() {
                 bootstrapper.with_mounted_file(
-                    lib_module_dir_path.clone(),
+                    lib_module_dir_path.as_str(),
                     config_schema,
                     PermissionLevel::Read,
                 );
             }
             if let Some(config) = module_info.get_config_file() {
                 bootstrapper.with_mounted_file(
-                    lib_module_dir_path.clone(),
+                    lib_module_dir_path.as_str(),
                     config,
                     PermissionLevel::Read,
                 );
             }
             if let Some(settings_schema) = module_info.get_settings_schema_file() {
                 bootstrapper.with_mounted_file(
-                    lib_module_dir_path.clone(),
+                    lib_module_dir_path.as_str(),
                     settings_schema,
                     PermissionLevel::Read,
                 );
             }
             if let Some(share_dir) = module_info.get_share() {
                 bootstrapper.with_mounted_dir(
-                    lib_module_dir_path.clone(),
+                    lib_module_dir_path.as_str(),
                     share_dir,
                     PermissionLevel::Read,
                 );

--- a/hermes/bin/src/packaging/app/mod.rs
+++ b/hermes/bin/src/packaging/app/mod.rs
@@ -296,11 +296,19 @@ impl ApplicationPackage {
 
     /// Mount `ApplicationPackage` content to the `Vfs`
     pub(crate) fn mount_to_vfs(&self, bootstrapper: &mut VfsBootstrapper) -> anyhow::Result<()> {
-        let root_path = "/";
-        bootstrapper.with_mounted_file(root_path, self.get_icon_file()?, PermissionLevel::Read);
-        bootstrapper.with_mounted_file(root_path, self.get_metadata_file()?, PermissionLevel::Read);
+        let root_path = "/".to_string();
+        bootstrapper.with_mounted_file(
+            root_path.clone(),
+            self.get_icon_file()?,
+            PermissionLevel::Read,
+        );
+        bootstrapper.with_mounted_file(
+            root_path.clone(),
+            self.get_metadata_file()?,
+            PermissionLevel::Read,
+        );
         if let Some(share_dir) = self.get_share_dir() {
-            bootstrapper.with_mounted_dir(root_path, share_dir, PermissionLevel::Read);
+            bootstrapper.with_mounted_dir(root_path.clone(), share_dir, PermissionLevel::Read);
         }
         if let Some(www_dir) = self.get_www_dir() {
             bootstrapper.with_mounted_dir(root_path, www_dir, PermissionLevel::Read);
@@ -308,42 +316,42 @@ impl ApplicationPackage {
 
         for module_info in self.get_modules()? {
             let lib_module_dir_path = format!("{}/{}", Vfs::LIB_DIR, module_info.get_name());
-            bootstrapper.with_dir_to_create(lib_module_dir_path.as_str(), PermissionLevel::Read);
+            bootstrapper.with_dir_to_create(lib_module_dir_path.clone(), PermissionLevel::Read);
 
             bootstrapper.with_mounted_file(
-                lib_module_dir_path.as_str(),
+                lib_module_dir_path.clone(),
                 module_info.get_metadata_file()?,
                 PermissionLevel::Read,
             );
             bootstrapper.with_mounted_file(
-                lib_module_dir_path.as_str(),
+                lib_module_dir_path.clone(),
                 module_info.get_component_file()?,
                 PermissionLevel::Read,
             );
             if let Some(config_schema) = module_info.get_config_schema_file() {
                 bootstrapper.with_mounted_file(
-                    lib_module_dir_path.as_str(),
+                    lib_module_dir_path.clone(),
                     config_schema,
                     PermissionLevel::Read,
                 );
             }
             if let Some(config) = module_info.get_config_file() {
                 bootstrapper.with_mounted_file(
-                    lib_module_dir_path.as_str(),
+                    lib_module_dir_path.clone(),
                     config,
                     PermissionLevel::Read,
                 );
             }
             if let Some(settings_schema) = module_info.get_settings_schema_file() {
                 bootstrapper.with_mounted_file(
-                    lib_module_dir_path.as_str(),
+                    lib_module_dir_path.clone(),
                     settings_schema,
                     PermissionLevel::Read,
                 );
             }
             if let Some(share_dir) = module_info.get_share() {
                 bootstrapper.with_mounted_dir(
-                    lib_module_dir_path.as_str(),
+                    lib_module_dir_path,
                     share_dir,
                     PermissionLevel::Read,
                 );

--- a/hermes/bin/src/packaging/app/mod.rs
+++ b/hermes/bin/src/packaging/app/mod.rs
@@ -26,7 +26,7 @@ use crate::{
         resources::{BytesResource, ResourceTrait},
         Dir, File, Path,
     },
-    vfs::{Vfs, VfsBootstrapper},
+    vfs::{PermissionLevel, Vfs, VfsBootstrapper},
 };
 
 /// Hermes application package.
@@ -297,39 +297,65 @@ impl ApplicationPackage {
     /// Mount `ApplicationPackage` content to the `Vfs`
     pub(crate) fn mount_to_vfs(&self, bootstrapper: &mut VfsBootstrapper) -> anyhow::Result<()> {
         let root_path = Path::default();
-        bootstrapper.with_mounted_file(root_path.clone(), self.get_icon_file()?);
-        bootstrapper.with_mounted_file(root_path.clone(), self.get_metadata_file()?);
+        bootstrapper.with_mounted_file(
+            root_path.clone(),
+            self.get_icon_file()?,
+            PermissionLevel::Read,
+        );
+        bootstrapper.with_mounted_file(
+            root_path.clone(),
+            self.get_metadata_file()?,
+            PermissionLevel::Read,
+        );
         if let Some(share_dir) = self.get_share_dir() {
-            bootstrapper.with_mounted_dir(root_path.clone(), share_dir);
+            bootstrapper.with_mounted_dir(root_path.clone(), share_dir, PermissionLevel::Read);
         }
         if let Some(www_dir) = self.get_www_dir() {
-            bootstrapper.with_mounted_dir(root_path.clone(), www_dir);
+            bootstrapper.with_mounted_dir(root_path.clone(), www_dir, PermissionLevel::Read);
         }
 
         for module_info in self.get_modules()? {
             let lib_module_dir_path: Path =
                 format!("{}/{}", Vfs::LIB_DIR, module_info.get_name()).into();
-            bootstrapper.with_dir_to_create(lib_module_dir_path.clone());
+            bootstrapper.with_dir_to_create(lib_module_dir_path.clone(), PermissionLevel::Read);
 
             bootstrapper.with_mounted_file(
                 lib_module_dir_path.clone(),
                 module_info.get_metadata_file()?,
+                PermissionLevel::Read,
             );
             bootstrapper.with_mounted_file(
                 lib_module_dir_path.clone(),
                 module_info.get_component_file()?,
+                PermissionLevel::Read,
             );
             if let Some(config_schema) = module_info.get_config_schema_file() {
-                bootstrapper.with_mounted_file(lib_module_dir_path.clone(), config_schema);
+                bootstrapper.with_mounted_file(
+                    lib_module_dir_path.clone(),
+                    config_schema,
+                    PermissionLevel::Read,
+                );
             }
             if let Some(config) = module_info.get_config_file() {
-                bootstrapper.with_mounted_file(lib_module_dir_path.clone(), config);
+                bootstrapper.with_mounted_file(
+                    lib_module_dir_path.clone(),
+                    config,
+                    PermissionLevel::Read,
+                );
             }
             if let Some(settings_schema) = module_info.get_settings_schema_file() {
-                bootstrapper.with_mounted_file(lib_module_dir_path.clone(), settings_schema);
+                bootstrapper.with_mounted_file(
+                    lib_module_dir_path.clone(),
+                    settings_schema,
+                    PermissionLevel::Read,
+                );
             }
             if let Some(share_dir) = module_info.get_share() {
-                bootstrapper.with_mounted_dir(lib_module_dir_path.clone(), share_dir);
+                bootstrapper.with_mounted_dir(
+                    lib_module_dir_path.clone(),
+                    share_dir,
+                    PermissionLevel::Read,
+                );
             }
         }
         Ok(())

--- a/hermes/bin/src/packaging/app/module_info.rs
+++ b/hermes/bin/src/packaging/app/module_info.rs
@@ -1,8 +1,8 @@
 //! An application's module info object
 
+use super::module::ModulePackage;
 use crate::{
     hdf5::{Dir, File},
-    packaging::module::ModulePackage,
     wasm::module::Module,
 };
 
@@ -30,32 +30,32 @@ impl AppModuleInfo {
     }
 
     /// Get module's WASM component file
-    pub(crate) fn get_component_file(&self) -> anyhow::Result<File> {
+    pub(super) fn get_component_file(&self) -> anyhow::Result<File> {
         self.package.get_component_file()
     }
 
     /// Get module's WASM metadata file
-    pub(crate) fn get_metadata_file(&self) -> anyhow::Result<File> {
+    pub(super) fn get_metadata_file(&self) -> anyhow::Result<File> {
         self.package.get_metadata_file()
     }
 
     /// Get module's WASM config schema file
-    pub(crate) fn get_config_schema_file(&self) -> Option<File> {
+    pub(super) fn get_config_schema_file(&self) -> Option<File> {
         self.package.get_config_schema_file()
     }
 
     /// Get module's WASM config file
-    pub(crate) fn get_config_file(&self) -> Option<File> {
+    pub(super) fn get_config_file(&self) -> Option<File> {
         self.app_config.clone().or(self.package.get_config_file())
     }
 
     /// Get module's WASM settings schema file
-    pub(crate) fn get_settings_schema_file(&self) -> Option<File> {
+    pub(super) fn get_settings_schema_file(&self) -> Option<File> {
         self.package.get_settings_schema_file()
     }
 
     /// Get module's share dir
-    pub(crate) fn get_share(&self) -> Option<Dir> {
+    pub(super) fn get_share(&self) -> Option<Dir> {
         self.app_share.clone().or(self.package.get_share())
     }
 }

--- a/hermes/bin/src/packaging/metadata.rs
+++ b/hermes/bin/src/packaging/metadata.rs
@@ -8,7 +8,7 @@ use std::{
 
 use chrono::{DateTime, Utc};
 
-use crate::packaging::schema_validation::SchemaValidator;
+use super::schema_validation::SchemaValidator;
 
 /// Metadata object.
 pub(crate) struct Metadata<T> {

--- a/hermes/bin/src/packaging/module/author_payload.rs
+++ b/hermes/bin/src/packaging/module/author_payload.rs
@@ -1,7 +1,7 @@
 //! A signature payload object for author.cose Hermes WASM module package.
 //! Defined at `https://input-output-hk.github.io/hermes/architecture/08_concepts/hermes_packaging_requirements/wasm_modules/#wasm-component-module-signatures`.
 
-use crate::packaging::{
+use super::super::{
     hash::Blake2b256, schema_validation::SchemaValidator, sign::signature::SignaturePayloadEncoding,
 };
 

--- a/hermes/bin/src/packaging/module/config.rs
+++ b/hermes/bin/src/packaging/module/config.rs
@@ -2,7 +2,7 @@
 
 use std::io::Read;
 
-use crate::packaging::schema_validation::SchemaValidator;
+use super::super::schema_validation::SchemaValidator;
 
 /// Config schema object.
 #[derive(Debug)]

--- a/hermes/bin/src/packaging/module/manifest.rs
+++ b/hermes/bin/src/packaging/module/manifest.rs
@@ -2,10 +2,8 @@
 
 use std::path::Path;
 
-use crate::{
-    hdf5::resources::{FsResource, ResourceBuilder},
-    packaging::{schema_validation::SchemaValidator, FileError},
-};
+use super::super::{schema_validation::SchemaValidator, FileError};
+use crate::hdf5::resources::{FsResource, ResourceBuilder};
 
 /// WASM module package manifest.json definition.
 #[derive(Debug, PartialEq, Eq)]

--- a/hermes/bin/src/packaging/module/mod.rs
+++ b/hermes/bin/src/packaging/module/mod.rs
@@ -11,21 +11,21 @@ pub(crate) use config::{Config, ConfigSchema};
 pub(crate) use manifest::{Manifest, ManifestConfig};
 pub(crate) use settings::SettingsSchema;
 
+use super::{
+    metadata::{Metadata, MetadataSchema},
+    package::Package,
+    sign::{
+        certificate::Certificate,
+        keys::PrivateKey,
+        signature::{Signature, SignaturePayloadEncoding},
+    },
+    FileError, MissingPackageFileError,
+};
 use crate::{
     errors::Errors,
     hdf5::{
         resources::{bytes::BytesResource, ResourceTrait},
         Dir, File, Path,
-    },
-    packaging::{
-        metadata::{Metadata, MetadataSchema},
-        package::Package,
-        sign::{
-            certificate::Certificate,
-            keys::PrivateKey,
-            signature::{Signature, SignaturePayloadEncoding},
-        },
-        FileError, MissingPackageFileError,
     },
     wasm::module::Module,
 };
@@ -44,7 +44,7 @@ impl ModulePackage {
     /// Module package WASM component file path.
     const COMPONENT_FILE: &'static str = "module.wasm";
     /// Module package config file path.
-    pub(crate) const CONFIG_FILE: &'static str = "config.json";
+    const CONFIG_FILE: &'static str = "config.json";
     /// Module package config schema file path.
     const CONFIG_SCHEMA_FILE: &'static str = "config.schema.json";
     /// Module package file extension.
@@ -54,7 +54,7 @@ impl ModulePackage {
     /// Module package settings schema file path.
     const SETTINGS_SCHEMA_FILE: &'static str = "settings.schema.json";
     /// Module package share directory path.
-    pub(crate) const SHARE_DIR: &'static str = "share";
+    const SHARE_DIR: &'static str = "share";
 
     /// Create a new module package from a manifest file.
     pub(crate) fn build_from_manifest<P: AsRef<std::path::Path>>(
@@ -190,7 +190,7 @@ impl ModulePackage {
     }
 
     /// Get metadata `File` object from package.
-    pub(crate) fn get_metadata_file(&self) -> anyhow::Result<File> {
+    pub(super) fn get_metadata_file(&self) -> anyhow::Result<File> {
         self.0
             .get_file(Self::METADATA_FILE.into())
             .map_err(|_| MissingPackageFileError(Self::METADATA_FILE.to_string()).into())
@@ -202,7 +202,7 @@ impl ModulePackage {
     }
 
     /// Get component `File` object from package.
-    pub(crate) fn get_component_file(&self) -> anyhow::Result<File> {
+    pub(super) fn get_component_file(&self) -> anyhow::Result<File> {
         self.0
             .get_file(Self::COMPONENT_FILE.into())
             .map_err(|_| MissingPackageFileError(Self::METADATA_FILE.to_string()).into())
@@ -223,7 +223,7 @@ impl ModulePackage {
     }
 
     /// Get config schema `File` object from package.
-    pub(crate) fn get_config_schema_file(&self) -> Option<File> {
+    pub(super) fn get_config_schema_file(&self) -> Option<File> {
         self.0.get_file(Self::CONFIG_SCHEMA_FILE.into()).ok()
     }
 
@@ -235,7 +235,7 @@ impl ModulePackage {
     }
 
     /// Get config `File` object from package.
-    pub(crate) fn get_config_file(&self) -> Option<File> {
+    pub(super) fn get_config_file(&self) -> Option<File> {
         self.0.get_file(Self::CONFIG_FILE.into()).ok()
     }
 
@@ -257,7 +257,7 @@ impl ModulePackage {
     }
 
     /// Get settings schema `File` object from package if present.
-    pub(crate) fn get_settings_schema_file(&self) -> Option<File> {
+    pub(super) fn get_settings_schema_file(&self) -> Option<File> {
         self.0.get_file(Self::SETTINGS_SCHEMA_FILE.into()).ok()
     }
 
@@ -269,7 +269,7 @@ impl ModulePackage {
     }
 
     /// Get share dir from package if present.
-    pub(crate) fn get_share(&self) -> Option<Dir> {
+    pub(super) fn get_share(&self) -> Option<Dir> {
         self.0.get_dir(&Self::SHARE_DIR.into()).ok()
     }
 

--- a/hermes/bin/src/packaging/module/settings.rs
+++ b/hermes/bin/src/packaging/module/settings.rs
@@ -2,7 +2,7 @@
 
 use std::io::Read;
 
-use crate::packaging::schema_validation::SchemaValidator;
+use super::super::schema_validation::SchemaValidator;
 
 /// Settings schema object.
 #[derive(Debug)]

--- a/hermes/bin/src/packaging/package/mod.rs
+++ b/hermes/bin/src/packaging/package/mod.rs
@@ -2,10 +2,8 @@
 
 use std::{collections::BTreeMap, io::Read, ops::Deref};
 
-use crate::{
-    hdf5::{Dir, File, Path},
-    packaging::hash::{Blake2b256, Blake2b256Hasher},
-};
+use super::hash::{Blake2b256, Blake2b256Hasher};
+use crate::hdf5::{Dir, File, Path};
 
 /// Hermes package object.
 /// Wrapper over HDF5 file object.

--- a/hermes/bin/src/packaging/sign/certificate/mod.rs
+++ b/hermes/bin/src/packaging/sign/certificate/mod.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 
 use x509_cert::der::{DecodePem, Encode};
 
-use crate::packaging::{hash::Blake2b256, sign::keys::PublicKey, FileError};
+use super::super::{hash::Blake2b256, sign::keys::PublicKey, FileError};
 
 /// Certificate decoding from string error.
 #[derive(thiserror::Error, Debug)]

--- a/hermes/bin/src/packaging/sign/certificate/storage.rs
+++ b/hermes/bin/src/packaging/sign/certificate/storage.rs
@@ -3,7 +3,7 @@
 use dashmap::DashMap;
 use once_cell::sync::Lazy;
 
-use crate::packaging::{hash::Blake2b256, sign::certificate::Certificate};
+use super::super::super::{hash::Blake2b256, sign::certificate::Certificate};
 
 /// Singleton `CertificateStorage` instance.
 static STORAGE: Lazy<CertificateStorage> = Lazy::new(CertificateStorage::new);

--- a/hermes/bin/src/packaging/sign/keys.rs
+++ b/hermes/bin/src/packaging/sign/keys.rs
@@ -10,7 +10,7 @@ use ed25519_dalek::{
     SigningKey, VerifyingKey,
 };
 
-use crate::packaging::FileError;
+use super::super::FileError;
 
 /// Public or private key decoding from string error.
 #[derive(thiserror::Error, Debug)]

--- a/hermes/bin/src/packaging/sign/signature.rs
+++ b/hermes/bin/src/packaging/sign/signature.rs
@@ -10,10 +10,11 @@ use coset::{
 };
 
 use super::{
+    super::hash::Blake2b256,
     certificate::{self, Certificate},
     keys::PrivateKey,
 };
-use crate::{errors::Errors, packaging::hash::Blake2b256};
+use crate::errors::Errors;
 
 /// COSE signature object.
 #[derive(Debug, Clone, PartialEq)]

--- a/hermes/bin/src/runtime_context.rs
+++ b/hermes/bin/src/runtime_context.rs
@@ -1,5 +1,7 @@
 //! Hermes runtime context implementation.
 
+use std::sync::Arc;
+
 use crate::{app::HermesAppName, vfs::Vfs, wasm::module::ModuleId};
 
 /// Hermes Runtime Context. This is passed to the WASM runtime.
@@ -19,14 +21,14 @@ pub(crate) struct HermesRuntimeContext {
 
     /// App Virtual file system
     #[allow(dead_code)]
-    vfs: Vfs,
+    vfs: Arc<Vfs>,
 }
 
 impl HermesRuntimeContext {
     /// Creates a new instance of the `Context`.
     pub(crate) fn new(
         app_name: HermesAppName, module_id: ModuleId, event_name: String, exc_counter: u32,
-        vfs: Vfs,
+        vfs: Arc<Vfs>,
     ) -> Self {
         Self {
             app_name,

--- a/hermes/bin/src/runtime_extensions/hermes/integration_test/event.rs
+++ b/hermes/bin/src/runtime_extensions/hermes/integration_test/event.rs
@@ -89,7 +89,9 @@ pub fn execute_event(
 
     let hermes_home_dir = TempDir::new()?;
 
-    let vfs = VfsBootstrapper::new(hermes_home_dir.path(), app_name.to_string()).bootstrap()?;
+    let vfs = VfsBootstrapper::new(hermes_home_dir.path(), app_name.to_string())
+        .bootstrap()?
+        .into();
 
     let result = match event_type {
         EventType::Bench => {

--- a/hermes/bin/src/utils.rs
+++ b/hermes/bin/src/utils.rs
@@ -1,0 +1,34 @@
+//! Generally used utility functions.
+
+/// Parse a path string into a vector of path elements applying the `/` and `\`
+/// delimiters.
+pub(crate) fn parse_path(path: &str) -> Vec<String> {
+    path.split(&['/', '\\'])
+        .map(ToString::to_string)
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_path_test() {
+        assert!(parse_path("").is_empty());
+
+        assert!(parse_path("/").is_empty());
+        assert_eq!(parse_path("/a"), vec!["a".to_string()]);
+        assert_eq!(parse_path("/a/b"), vec!["a".to_string(), "b".to_string()]);
+
+        assert!(parse_path(r"\").is_empty());
+        assert_eq!(parse_path(r"\a"), vec!["a".to_string()]);
+        assert_eq!(parse_path(r"\a\b"), vec!["a".to_string(), "b".to_string()]);
+
+        assert_eq!(parse_path("//a//b"), vec!["a".to_string(), "b".to_string()]);
+        assert_eq!(parse_path(r"\\a\\b"), vec![
+            "a".to_string(),
+            "b".to_string()
+        ]);
+    }
+}

--- a/hermes/bin/src/vfs/bootstrap.rs
+++ b/hermes/bin/src/vfs/bootstrap.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use hdf5 as hdf5_lib;
 
 use super::{
-    permission::{PermissionLevel, PermissionsTree},
+    permission::{PermissionLevel, PermissionsState},
     Vfs,
 };
 use crate::hdf5 as hermes_hdf5;
@@ -23,7 +23,7 @@ pub(crate) struct VfsBootstrapper {
     /// HDF5 directories to create
     dirs_to_create: Vec<DitToCreate>,
     /// VFS permissions state.
-    permissions: PermissionsTree,
+    permissions: PermissionsState,
 }
 
 /// Directory to create object.
@@ -63,7 +63,7 @@ impl VfsBootstrapper {
             mounted_files: Vec::new(),
             mounted_dirs: Vec::new(),
             dirs_to_create: Vec::new(),
-            permissions: PermissionsTree::new(),
+            permissions: PermissionsState::new(),
         }
     }
 

--- a/hermes/bin/src/vfs/bootstrap.rs
+++ b/hermes/bin/src/vfs/bootstrap.rs
@@ -193,7 +193,7 @@ impl VfsBootstrapper {
         let path_str = format!("{}/{}", mounted.to_path, mounted.dir.name());
         permissions.add_permission(path_str.as_str(), mounted.permission);
         let path: hermes_hdf5::Path = path_str.into();
-        let _unused = root.remove_file(path.clone());
+        let _unused = root.remove_dir(path.clone());
         root.mount_dir(&mounted.dir, path)?;
         Ok(())
     }

--- a/hermes/bin/src/vfs/bootstrap.rs
+++ b/hermes/bin/src/vfs/bootstrap.rs
@@ -30,9 +30,6 @@ pub(crate) struct VfsBootstrapper {
 struct DitToCreate {
     /// HDF5 directory path.
     path: hermes_hdf5::Path,
-    /// Permission level.
-    #[allow(dead_code)]
-    permission: PermissionLevel,
 }
 
 /// Mounted file object.
@@ -41,9 +38,6 @@ struct MountedFile {
     path: hermes_hdf5::Path,
     /// HDF5 file.
     file: hermes_hdf5::File,
-    /// Permission level.
-    #[allow(dead_code)]
-    permission: PermissionLevel,
 }
 
 /// Mounted directory object.
@@ -52,9 +46,6 @@ struct MountedDir {
     path: hermes_hdf5::Path,
     /// HDF5 directory.
     dir: hermes_hdf5::Dir,
-    /// Permission level.
-    #[allow(dead_code)]
-    permission: PermissionLevel,
 }
 
 impl VfsBootstrapper {
@@ -71,31 +62,30 @@ impl VfsBootstrapper {
     }
 
     /// Add a `Dir` creation by the provided path during bootstrapping
-    pub(crate) fn with_dir_to_create(
-        &mut self, path: hermes_hdf5::Path, permission: PermissionLevel,
-    ) {
-        self.dirs_to_create.push(DitToCreate { path, permission });
+    pub(crate) fn with_dir_to_create(&mut self, path: &str, permission: PermissionLevel) {
+        self.permissions.add_permission(path, permission);
+        self.dirs_to_create.push(DitToCreate { path: path.into() });
     }
 
     /// Add a mounted file
     pub(crate) fn with_mounted_file(
-        &mut self, to: hermes_hdf5::Path, file: hermes_hdf5::File, permission: PermissionLevel,
+        &mut self, to: &str, file: hermes_hdf5::File, permission: PermissionLevel,
     ) {
+        self.permissions.add_permission(to, permission);
         self.mounted_files.push(MountedFile {
-            path: to,
+            path: to.into(),
             file,
-            permission,
         });
     }
 
     /// Add a mounted dir
     pub(crate) fn with_mounted_dir(
-        &mut self, to: hermes_hdf5::Path, dir: hermes_hdf5::Dir, permission: PermissionLevel,
+        &mut self, to: &str, dir: hermes_hdf5::Dir, permission: PermissionLevel,
     ) {
+        self.permissions.add_permission(to, permission);
         self.mounted_dirs.push(MountedDir {
-            path: to,
+            path: to.into(),
             dir,
-            permission,
         });
     }
 
@@ -216,20 +206,20 @@ mod tests {
         let vfs_name = "test_vfs".to_string();
         let mut bootstrapper = VfsBootstrapper::new(tmp_dir.path(), vfs_name.clone());
 
-        bootstrapper.with_mounted_file("/".into(), file.clone(), PermissionLevel::ReadAndWrite);
+        bootstrapper.with_mounted_file("/", file.clone(), PermissionLevel::ReadAndWrite);
 
         let dir_to_create_name = "new_dir";
         bootstrapper.with_dir_to_create(
-            format!("{}/{dir_to_create_name}", Vfs::LIB_DIR).into(),
+            format!("{}/{dir_to_create_name}", Vfs::LIB_DIR).as_str(),
             PermissionLevel::ReadAndWrite,
         );
         bootstrapper.with_mounted_file(
-            format!("{}/{dir_to_create_name}", Vfs::LIB_DIR).into(),
+            format!("{}/{dir_to_create_name}", Vfs::LIB_DIR).as_str(),
             file.clone(),
             PermissionLevel::ReadAndWrite,
         );
         bootstrapper.with_mounted_dir(
-            format!("{}/{dir_to_create_name}", Vfs::LIB_DIR).into(),
+            format!("{}/{dir_to_create_name}", Vfs::LIB_DIR).as_str(),
             dir1.clone(),
             PermissionLevel::ReadAndWrite,
         );
@@ -249,19 +239,19 @@ mod tests {
 
         drop(vfs);
         let mut bootstrapper = VfsBootstrapper::new(tmp_dir.path(), vfs_name.clone());
-        bootstrapper.with_mounted_file("/".into(), file.clone(), PermissionLevel::ReadAndWrite);
+        bootstrapper.with_mounted_file("/", file.clone(), PermissionLevel::ReadAndWrite);
         let dir_to_create_name = "new_dir";
         bootstrapper.with_dir_to_create(
-            format!("{}/{dir_to_create_name}", Vfs::LIB_DIR).into(),
+            format!("{}/{dir_to_create_name}", Vfs::LIB_DIR).as_str(),
             PermissionLevel::ReadAndWrite,
         );
         bootstrapper.with_mounted_file(
-            format!("{}/{dir_to_create_name}", Vfs::LIB_DIR).into(),
+            format!("{}/{dir_to_create_name}", Vfs::LIB_DIR).as_str(),
             file.clone(),
             PermissionLevel::ReadAndWrite,
         );
         bootstrapper.with_mounted_dir(
-            format!("{}/{dir_to_create_name}", Vfs::LIB_DIR).into(),
+            format!("{}/{dir_to_create_name}", Vfs::LIB_DIR).as_str(),
             dir1.clone(),
             PermissionLevel::ReadAndWrite,
         );

--- a/hermes/bin/src/vfs/bootstrap.rs
+++ b/hermes/bin/src/vfs/bootstrap.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use hdf5 as hdf5_lib;
 
-use super::Vfs;
+use super::{permission::PermissionsTree, Vfs};
 use crate::hdf5 as hermes_hdf5;
 
 /// Hermes virtual file system builder.
@@ -74,7 +74,10 @@ impl VfsBootstrapper {
             &self.mounted_dirs,
         )?;
 
-        Ok(Vfs { root })
+        Ok(Vfs {
+            root,
+            permissions: PermissionsTree::new(),
+        })
     }
 
     /// Setup hdf5 VFS directories structure.

--- a/hermes/bin/src/vfs/mod.rs
+++ b/hermes/bin/src/vfs/mod.rs
@@ -6,8 +6,8 @@ mod permission;
 use std::io::{Read, Write};
 
 pub(crate) use bootstrap::VfsBootstrapper;
+use permission::PermissionsTree;
 
-// use permission::PermissionsTree;
 use crate::hdf5 as hermes_hdf5;
 
 /// Hermes virtual file system type.
@@ -15,7 +15,9 @@ use crate::hdf5 as hermes_hdf5;
 pub(crate) struct Vfs {
     /// HDF5 root directory of the virtual file system.
     root: hermes_hdf5::Dir,
-    // permissions: PermissionsTree,
+    /// VFS permissions state.
+    #[allow(dead_code)]
+    permissions: PermissionsTree,
 }
 
 impl Vfs {

--- a/hermes/bin/src/vfs/mod.rs
+++ b/hermes/bin/src/vfs/mod.rs
@@ -7,14 +7,15 @@ use std::io::{Read, Write};
 
 pub(crate) use bootstrap::VfsBootstrapper;
 
+// use permission::PermissionsTree;
 use crate::hdf5 as hermes_hdf5;
 
 /// Hermes virtual file system type.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub(crate) struct Vfs {
     /// HDF5 root directory of the virtual file system.
     root: hermes_hdf5::Dir,
-    // TODO: add permissions RWX
+    // permissions: PermissionsTree,
 }
 
 impl Vfs {

--- a/hermes/bin/src/vfs/mod.rs
+++ b/hermes/bin/src/vfs/mod.rs
@@ -89,12 +89,21 @@ mod tests {
 
         let vfs = bootstrapper.bootstrap().expect("Cannot bootstrap");
 
-        let file_path = format!("{}/www.txt", Vfs::SRV_DIR);
+        let file_name = "www.txt";
         let file_content = b"web_server";
-        vfs.write(file_path.as_str(), file_content)
+        assert!(
+            vfs.write(
+                format!("{}/{file_name}", Vfs::SRV_DIR).as_str(),
+                file_content
+            )
+            .is_err(),
+            "Cannot write to the 'read only' directory"
+        );
+
+        vfs.write(file_name, file_content)
             .expect("Cannot write to VFS");
 
-        let written_data = vfs.read(file_path.as_str()).expect("Cannot read from VFS");
+        let written_data = vfs.read(file_name).expect("Cannot read from VFS");
         assert_eq!(written_data.as_slice(), file_content);
     }
 }

--- a/hermes/bin/src/vfs/mod.rs
+++ b/hermes/bin/src/vfs/mod.rs
@@ -1,6 +1,7 @@
 //! Hermes virtual file system.
 
 mod bootstrap;
+mod permission;
 
 use std::io::{Read, Write};
 

--- a/hermes/bin/src/vfs/mod.rs
+++ b/hermes/bin/src/vfs/mod.rs
@@ -7,7 +7,7 @@ use std::io::{Read, Write};
 
 pub(crate) use bootstrap::VfsBootstrapper;
 pub(crate) use permission::PermissionLevel;
-use permission::PermissionsTree;
+use permission::PermissionsState;
 
 use crate::hdf5 as hermes_hdf5;
 
@@ -17,7 +17,7 @@ pub(crate) struct Vfs {
     /// HDF5 root directory of the virtual file system.
     root: hermes_hdf5::Dir,
     /// VFS permissions state.
-    permissions: PermissionsTree,
+    permissions: PermissionsState,
 }
 
 impl Vfs {

--- a/hermes/bin/src/vfs/permission.rs
+++ b/hermes/bin/src/vfs/permission.rs
@@ -1,36 +1,49 @@
 //! Permissions state management of the Hermes virtual file system.
 
-#![allow(dead_code, missing_docs, clippy::missing_docs_in_private_items)]
+#![allow(dead_code)]
 
 use std::{cell::RefCell, collections::HashMap, rc::Rc};
 
 use crate::utils::parse_path;
 
+/// Permission level type.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 enum PermissionLevel {
+    /// Read only permission level.
     Read,
+    /// Read and write permission level.
     #[default]
     ReadAndWrite,
 }
 
+/// VFS permissions state stored in the radix tree structure, where the
+/// each node relates to a single path element with the permission level.
 struct PermissionsTree {
+    /// Tree's root node.
     root: PermissionNodeRef,
 }
 
+/// `PermissionsTree` node type.
 #[derive(Default)]
 struct PermissionNode {
+    /// Node permission level.
     permission: PermissionLevel,
+    /// Node childs.
     childs: HashMap<String, PermissionNodeRef>,
 }
 
+/// Convinient type of the referenced `PermissionNode`.
 type PermissionNodeRef = Rc<RefCell<PermissionNode>>;
 
 impl PermissionsTree {
+    /// Creates a new `PermissionsTree` instance with the root node which releates to the
+    /// "/" path with the `PermissionLevel::ReadAndWrite` default permission level.
     fn new() -> Self {
         let root = PermissionNodeRef::default();
         Self { root }
     }
 
+    /// Adds a new path to the `PermissionsTree` with the provided permission level.
     fn add_permission(&mut self, path: &str, permission: PermissionLevel) {
         let path_elements = parse_path(path);
 
@@ -50,6 +63,7 @@ impl PermissionsTree {
         walk.borrow_mut().permission = permission;
     }
 
+    /// Gets the permission level for the provided path.
     fn get_permission(&self, path: &str) -> PermissionLevel {
         let mut permission = self.root.borrow().permission;
 

--- a/hermes/bin/src/vfs/permission.rs
+++ b/hermes/bin/src/vfs/permission.rs
@@ -8,7 +8,7 @@ use crate::utils::parse_path;
 
 /// Permission level type.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
-enum PermissionLevel {
+pub(crate) enum PermissionLevel {
     /// Read only permission level.
     Read,
     /// Read and write permission level.
@@ -18,13 +18,14 @@ enum PermissionLevel {
 
 /// VFS permissions state stored in the radix tree structure, where the
 /// each node relates to a single path element with the permission level.
-struct PermissionsTree {
+#[derive(Debug)]
+pub(crate) struct PermissionsTree {
     /// Tree's root node.
     root: PermissionNodeRef,
 }
 
 /// `PermissionsTree` node type.
-#[derive(Default)]
+#[derive(Default, Debug)]
 struct PermissionNode {
     /// Node permission level.
     permission: PermissionLevel,

--- a/hermes/bin/src/vfs/permission.rs
+++ b/hermes/bin/src/vfs/permission.rs
@@ -4,6 +4,8 @@
 
 use std::{cell::RefCell, collections::HashMap, rc::Rc};
 
+use crate::utils::parse_path;
+
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 enum PermissionLevel {
     Read,
@@ -67,13 +69,6 @@ impl PermissionsTree {
 
         permission
     }
-}
-
-fn parse_path(path: &str) -> Vec<String> {
-    path.split(&['/', '\\'])
-        .map(ToString::to_string)
-        .filter(|s| !s.is_empty())
-        .collect()
 }
 
 #[cfg(test)]

--- a/hermes/bin/src/vfs/permission.rs
+++ b/hermes/bin/src/vfs/permission.rs
@@ -1,7 +1,5 @@
 //! Permissions state management of the Hermes virtual file system.
 
-#![allow(dead_code)]
-
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc,
@@ -79,6 +77,7 @@ impl PermissionsTree {
     }
 
     /// Adds a new path to the `PermissionsTree` with the provided permission level.
+    #[allow(dead_code)]
     pub(crate) fn add_permission(&mut self, path: &str, permission: PermissionLevel) {
         let path_elements = parse_path(path);
 

--- a/hermes/bin/src/vfs/permission.rs
+++ b/hermes/bin/src/vfs/permission.rs
@@ -1,0 +1,99 @@
+//! Permissions state management of the Hermes virtual file system.
+
+#![allow(dead_code, missing_docs, clippy::missing_docs_in_private_items)]
+
+use std::{cell::RefCell, collections::HashMap, rc::Rc};
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+enum PermissionLevel {
+    Read,
+    #[default]
+    ReadAndWrite,
+}
+
+struct PermissionsTree {
+    root: PermissionNodeRef,
+}
+
+#[derive(Default)]
+struct PermissionNode {
+    permission: PermissionLevel,
+    childs: HashMap<String, PermissionNodeRef>,
+}
+
+type PermissionNodeRef = Rc<RefCell<PermissionNode>>;
+
+impl PermissionsTree {
+    fn new() -> Self {
+        let root = PermissionNodeRef::default();
+        Self { root }
+    }
+
+    fn add_permission(&mut self, path: &str, permission: PermissionLevel) {
+        let path_elements = parse_path(path);
+
+        let mut walk = self.root.clone();
+        for path_element in path_elements {
+            let node = walk.clone();
+            let mut node = node.borrow_mut();
+            if let Some(child_node) = node.childs.get(&path_element) {
+                walk = child_node.clone();
+            } else {
+                let new_node = PermissionNodeRef::default();
+                node.childs.insert(path_element, new_node.clone());
+                walk = new_node;
+            }
+        }
+        // Update the last node with the provided permission
+        walk.borrow_mut().permission = permission;
+    }
+
+    fn get_permission(&self, path: &str) -> PermissionLevel {
+        let mut permission = self.root.borrow().permission;
+
+        let path_elements = parse_path(path);
+
+        let mut walk = self.root.clone();
+        for path_element in path_elements {
+            let node = walk.clone();
+            let node = node.borrow();
+            if let Some(child_node) = node.childs.get(&path_element) {
+                permission = child_node.borrow().permission;
+                walk = child_node.clone();
+            } else {
+                break;
+            }
+        }
+
+        permission
+    }
+}
+
+fn parse_path(path: &str) -> Vec<String> {
+    path.split(&['/', '\\'])
+        .map(ToString::to_string)
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn permission_tree_test() {
+        let mut tree = PermissionsTree::new();
+
+        assert_eq!(tree.get_permission(""), PermissionLevel::ReadAndWrite);
+        assert_eq!(tree.get_permission("/a/b"), PermissionLevel::ReadAndWrite);
+        assert_eq!(tree.get_permission(r"\a\b"), PermissionLevel::ReadAndWrite);
+
+        tree.add_permission("/a/b", PermissionLevel::Read);
+        tree.add_permission("c/b", PermissionLevel::Read);
+
+        assert_eq!(tree.get_permission("a"), PermissionLevel::ReadAndWrite);
+        assert_eq!(tree.get_permission("a/b"), PermissionLevel::Read);
+        assert_eq!(tree.get_permission("c"), PermissionLevel::ReadAndWrite);
+        assert_eq!(tree.get_permission("c/b"), PermissionLevel::Read);
+    }
+}


### PR DESCRIPTION
# Description

Adding Hermes virtual file system permissions handling system.
The permissions state struct is based on the Radix tree structure, where each node is a path element with the corresponding permission level value.
By default each file and directory has a `ReadAndWrite` permission level.

## Related Issue(s)

#308 

## Description of Changes

- Updated `Vfs` and `VfsBotstrapper` structs, added permissions setup and usage.
- Added new `PermissionsState` and `PermissionLevel` types.
- Updated `AppPackage::mount_to_vfs` function with adding proper values of permission levels. 

