### PR TITLE
fix: Fixed `cardano` and `wasi-filesystem` WASM component builds

### DIFF
--- a/wasm/integration-test/cardano/Earthfile
+++ b/wasm/integration-test/cardano/Earthfile
@@ -15,7 +15,7 @@ build:
     COPY Cargo.toml .
     COPY wasi+build-rust-bindings/hermes.rs src/hermes.rs
 
-    DO rust-ci+CARGO --args "+nightly build --target wasm32-wasip1 --release" \
+    DO rust-ci+CARGO --args "build --target wasm32-wasip1 --release" \
         --output="wasm32-wasip1/release/cardano_rte_test_component.wasm"
 
     COPY wasi-hermes-component-adapter+build/wasi-hermes-component-adapter.wasm wasi_snapshot_preview1.wasm

--- a/wasm/integration-test/wasi-filesystem/Earthfile
+++ b/wasm/integration-test/wasi-filesystem/Earthfile
@@ -15,7 +15,7 @@ build:
     COPY Cargo.toml .
     COPY wasi+build-rust-bindings/hermes.rs src/hermes.rs
 
-    DO rust-ci+CARGO --args "+nightly build --target wasm32-wasip1 --release" \
+    DO rust-ci+CARGO --args "build --target wasm32-wasip1 --release" \
         --output="wasm32-wasip1/release/wasi_filesystem.wasm"
 
     COPY wasi-hermes-component-adapter+build/wasi-hermes-component-adapter.wasm wasi_snapshot_preview1.wasm


### PR DESCRIPTION
# Description

Fixed `+build` earthly target for `cardano` and `wasi-filesystem` WASM components for `aarch64` platform.
For some reason it fails on `+nightly` channel with such error
```
              +build | error: linking with `cc` failed: exit status: 1
            ...
              +build |   = note: /usr/lib/gcc/aarch64-alpine-linux-musl/13.2.1/../../../../aarch64-alpine-linux-musl/bin/ld: /usr/local/rustup/toolchains/nightly-aarch64-unknown-linux-musl/lib/rustlib/aarch64-unknown-linux-musl/lib/self-contained/libc.a(vfprintf.lo): in function `pop_arg':
              +build |           /build/musl-cross-make/build/local/aarch64-linux-musl/obj_musl/../src_musl/src/stdio/vfprintf.c:128:(.text.pop_arg+0x1e4): undefined reference to `__extenddftf2'
              +build |           /usr/lib/gcc/aarch64-alpine-linux-musl/13.2.1/../../../../aarch64-alpine-linux-musl/bin/ld: /usr/local/rustup/toolchains/nightly-aarch64-unknown-linux-musl/lib/rustlib/aarch64-unknown-linux-musl/lib/self-contained/libc.a(vfprintf.lo): in function `fmt_fp':
              +build |           /build/musl-cross-make/build/local/aarch64-linux-musl/obj_musl/../src_musl/src/stdio/vfprintf.c:210:(.text.fmt_fp+0x140): undefined reference to `__addtf3'
              +build |           /usr/lib/gcc/aarch64-alpine-linux-musl/13.2.1/../../../../aarch64-alpine-linux-musl/bin/ld: /build/musl-cross-make/build/local/aarch64-linux-musl/obj_musl/../src_musl/src/stdio/vfprintf.c:228:(.text.fmt_fp+0x1d8): undefined reference to `__subtf3'
              +build |           /usr/lib/gcc/aarch64-alpine-linux-musl/13.2.1/../../../../aarch64-alpine-linux-musl/bin/ld: /build/musl-cross-make/build/local/aarch64-linux-musl/obj_musl/../src_musl/src/stdio/vfprintf.c:229:(.text.fmt_fp+0x1e8): undefined reference to `__addtf3'
              +build |           /usr/lib/gcc/aarch64-alpine-linux-musl/13.2.1/../../../../aarch64-alpine-linux-musl/bin/ld: /build/musl-cross-make/build/local/aarch64-linux-musl/obj_musl/../src_musl/src/stdio/vfprintf.c:244:(.text.fmt_fp+0x288): undefined reference to `__fixtfsi'
              +build |           /usr/lib/gcc/aarch64-alpine-linux-musl/13.2.1/../../../../aarch64-alpine-linux-musl/bin/ld: /build/musl-cross-make/build/local/aarch64-linux-musl/obj_musl/../src_musl/src/stdio/vfprintf.c:246:(.text.fmt_fp+0x2b0): undefined reference to `__subtf3'
              +build |           /usr/lib/gcc/aarch64-alpine-linux-musl/13.2.1/../../../../aarch64-alpine-linux-musl/bin/ld: /build/musl-cross-make/build/local/aarch64-linux-musl/obj_musl/../src_musl/src/stdio/vfprintf.c:246:(.text.fmt_fp+0x2c0): undefined reference to `__multf3'
              +build |           /usr/lib/gcc/aarch64-alpine-linux-musl/13.2.1/../../../../aarch64-alpine-linux-musl/bin/ld: /build/musl-cross-make/build/local/aarch64-linux-musl/obj_musl/../src_musl/src/stdio/vfprintf.c:225:(.text.fmt_fp+0x394): undefined reference to `__multf3'
              +build |           /usr/lib/gcc/aarch64-alpine-linux-musl/13.2.1/../../../../aarch64-alpine-linux-musl/bin/ld: /build/musl-cross-make/build/local/aarch64-linux-musl/obj_musl/../src_musl/src/stdio/vfprintf.c:232:(.text.fmt_fp+0x3b0): undefined reference to `__addtf3'
              +build |           /usr/lib/gcc/aarch64-alpine-linux-musl/13.2.1/../../../../aarch64-alpine-linux-musl/bin/ld: /build/musl-cross-make/build/local/aarch64-linux-musl/obj_musl/../src_musl/src/stdio/vfprintf.c:233:(.text.fmt_fp+0x3bc): undefined reference to `__subtf3'
              +build |           /usr/lib/gcc/aarch64-alpine-linux-musl/13.2.1/../../../../aarch64-alpine-linux-musl/bin/ld: /build/musl-cross-make/build/local/aarch64-linux-musl/obj_musl/../src_musl/src/stdio/vfprintf.c:268:(.text.fmt_fp+0x4dc): undefined reference to `__multf3'
              +build |           /usr/lib/gcc/aarch64-alpine-linux-musl/13.2.1/../../../../aarch64-alpine-linux-musl/bin/ld: /build/musl-cross-make/build/local/aarch64-linux-musl/obj_musl/../src_musl/src/stdio/vfprintf.c:274:(.text.fmt_fp+0x528): undefined reference to `__fixunstfsi'
              +build |           /usr/lib/gcc/aarch64-alpine-linux-musl/13.2.1/../../../../aarch64-alpine-linux-musl/bin/ld: /build/musl-cross-make/build/local/aarch64-linux-musl/obj_musl/../src_musl/src/stdio/vfprintf.c:275:(.text.fmt_fp+0x540): undefined reference to `__subtf3'
              +build |           /usr/lib/gcc/aarch64-alpine-linux-musl/13.2.1/../../../../aarch64-alpine-linux-musl/bin/ld: /build/musl-cross-make/build/local/aarch64-linux-musl/obj_musl/../src_musl/src/stdio/vfprintf.c:275:(.text.fmt_fp+0x550): undefined reference to `__multf3'
              +build |           /usr/lib/gcc/aarch64-alpine-linux-musl/13.2.1/../../../../aarch64-alpine-linux-musl/bin/ld: /build/musl-cross-make/build/local/aarch64-linux-musl/obj_musl/../src_musl/src/stdio/vfprintf.c:331:(.text.fmt_fp+0x708): undefined reference to `__addtf3'
              +build |           /usr/lib/gcc/aarch64-alpine-linux-musl/13.2.1/../../../../aarch64-alpine-linux-musl/bin/ld: /usr/local/rustup/toolchains/nightly-aarch64-unknown-linux-musl/lib/rustlib/aarch64-unknown-linux-musl/lib/self-contained/libc.a(frexpl.lo): in function `frexpl':
              +build |           /build/musl-cross-make/build/local/aarch64-linux-musl/obj_musl/../src_musl/src/math/frexpl.c:16:(.text.frexpl+0x44): undefined reference to `__multf3'
              +build |           collect2: error: ld returned 1 exit status
```