### PR TITLE
test(chain-follower): Add unit tests to metadata decoding on CIP36

### DIFF
--- a/hermes/crates/cardano-chain-follower/src/metadata/cip36.rs
+++ b/hermes/crates/cardano-chain-follower/src/metadata/cip36.rs
@@ -1002,6 +1002,29 @@ mod tests {
     }
 
     #[test]
+    fn test_decode_stake_pub_2() {
+        let bytes_cases: &[Vec<u8>] = &[
+            vec![],
+            hex::decode(
+                // 0xe3cd2404c84de65f96918f18d5b445bcb933a7cda18eeded7945dd19 (28 bytes)
+                "581CE3CD2404C84DE65F96918F18D5B445BCB933A7CDA18EEDED7945DD19"
+            ).expect("cannot decode hex")
+        ];
+
+        for bytes in bytes_cases {
+            let decoded_metadata = DecodedMetadata(SkipMap::new());
+            let mut cip36 = create_empty_cip36(false);
+            let mut decoder = Decoder::new(&bytes);
+            let mut report = ValidationReport::new();
+
+            let rc = cip36.decode_stake_pub(&mut decoder, &mut report, &decoded_metadata);
+
+            assert_eq!(report.len(), 1);
+            assert_eq!(rc, None);
+        }
+    }
+
+    #[test]
     // cip-36 version
     fn test_decode_voting_key_1() {
         let hex_data = hex::decode(
@@ -1039,5 +1062,33 @@ mod tests {
         assert_eq!(cip36.cip36, Some(false));
         assert_eq!(cip36.voting_keys.len(), 1);
         assert_eq!(rc, Some(1));
+    }
+
+    #[test]
+    // cip-36 version
+    fn test_decode_voting_key_3() {
+        let bytes_cases: &[Vec<u8>] = &[
+            vec![],
+            hex::decode(
+                // [[]] (empty)
+                "8180"
+            ).expect("cannot decode hex"),
+            hex::decode(
+                // [["0x0036ef3e1f0d3f5989e2d155ea54bdb2a72c4c456ccb959af4c94868f473f5a0"]] (without weight)
+                "818158200036EF3E1F0D3F5989E2D155EA54BDB2A72C4C456CCB959AF4C94868F473F5A0"
+            ).expect("cannot decode hex")
+        ];
+
+        for bytes in bytes_cases {
+            let decoded_metadata = DecodedMetadata(SkipMap::new());
+            let mut cip36 = create_empty_cip36(false);
+            let mut decoder = Decoder::new(&bytes);
+            let mut report = ValidationReport::new();
+    
+            let rc = cip36.decode_voting_key(&mut decoder, &mut report, &decoded_metadata);
+    
+            assert_eq!(report.len(), 1);
+            assert_eq!(rc, None);
+        }
     }
 }

--- a/hermes/crates/cardano-chain-follower/src/metadata/cip36.rs
+++ b/hermes/crates/cardano-chain-follower/src/metadata/cip36.rs
@@ -932,7 +932,6 @@ mod tests {
     }
 
     #[test]
-    // valid `nonce`, errors
     fn test_decode_nonce_4() {
         let bytes_cases: &[&[u8]] = &[
             &[ 0x80 ], // array(0)
@@ -1065,7 +1064,6 @@ mod tests {
     }
 
     #[test]
-    // cip-36 version
     fn test_decode_voting_key_3() {
         let bytes_cases: &[Vec<u8>] = &[
             vec![],

--- a/hermes/crates/cardano-chain-follower/src/metadata/cip36.rs
+++ b/hermes/crates/cardano-chain-follower/src/metadata/cip36.rs
@@ -957,6 +957,33 @@ mod tests {
     }
 
     #[test]
+    fn test_decode_payment_address_1() {
+        let hex_data = hex::decode(
+            // 0x004777561e7d9ec112ec307572faec1aff61ff0cfed68df4cd5c847f1872b617657881e30ad17c46e4010c9cb3ebb2440653a34d32219c83e9
+            "5839004777561E7D9EC112EC307572FAEC1AFF61FF0CFED68DF4CD5C847F1872B617657881E30AD17C46E4010C9CB3EBB2440653A34D32219C83E9"
+        ).expect("cannot decode hex");
+        let decoded_metadata = DecodedMetadata(SkipMap::new());
+        let mut cip36 = create_empty_cip36(false);
+        let mut decoder = Decoder::new(&hex_data);
+        let mut report = ValidationReport::new();
+        let multi_era_tx: *const MultiEraTx = std::ptr::null();
+        let multi_era_tx = unsafe { &*multi_era_tx };
+
+        let rc = cip36.decode_payment_address(
+            &mut decoder,
+            &mut
+            report, &decoded_metadata,
+            multi_era_tx,
+            Network::Preprod
+        );
+
+        assert_eq!(report.len(), 0);
+        assert_eq!(cip36.payable, true);
+        assert_eq!(cip36.payment_addr.len(), 57);
+        assert_eq!(rc, Some(57));
+    }
+
+    #[test]
     fn test_decode_stake_pub_1() {
         let hex_data = hex::decode(
             // 0xe3cd2404c84de65f96918f18d5b445bcb933a7cda18eeded7945dd191e432369

--- a/hermes/crates/cardano-chain-follower/src/metadata/cip36.rs
+++ b/hermes/crates/cardano-chain-follower/src/metadata/cip36.rs
@@ -805,7 +805,7 @@ mod tests {
 
     fn create_empty_cip36(strict: bool) -> Cip36 {
         Cip36 {
-            cip36: Some(true),
+            cip36: None,
             voting_keys: vec![],
             stake_pk: None,
             payment_addr: vec![],
@@ -954,5 +954,45 @@ mod tests {
             assert_eq!(cip36.nonce, 0);
             assert_eq!(rc, None);
         }
+    }
+
+    #[test]
+    // cip-36 version
+    fn test_decode_voting_key_1() {
+        let hex_data = hex::decode(
+            // [["0x0036ef3e1f0d3f5989e2d155ea54bdb2a72c4c456ccb959af4c94868f473f5a0", 1]]
+            "818258200036EF3E1F0D3F5989E2D155EA54BDB2A72C4C456CCB959AF4C94868F473F5A001"
+        ).expect("cannot decode hex");
+        let decoded_metadata = DecodedMetadata(SkipMap::new());
+        let mut cip36 = create_empty_cip36(false);
+        let mut decoder = Decoder::new(&hex_data);
+        let mut report = ValidationReport::new();
+
+        let rc = cip36.decode_voting_key(&mut decoder, &mut report, &decoded_metadata);
+
+        assert_eq!(report.len(), 0);
+        assert_eq!(cip36.cip36, Some(true));
+        assert_eq!(cip36.voting_keys.len(), 1);
+        assert_eq!(rc, Some(1));
+    }
+
+    #[test]
+    // cip-15 version
+    fn test_decode_voting_key_2() {
+        let hex_data = hex::decode(
+            // 0x0036ef3e1f0d3f5989e2d155ea54bdb2a72c4c456ccb959af4c94868f473f5a0
+            "58200036EF3E1F0D3F5989E2D155EA54BDB2A72C4C456CCB959AF4C94868F473F5A0"
+        ).expect("cannot decode hex");
+        let decoded_metadata = DecodedMetadata(SkipMap::new());
+        let mut cip36 = create_empty_cip36(false);
+        let mut decoder = Decoder::new(&hex_data);
+        let mut report = ValidationReport::new();
+
+        let rc = cip36.decode_voting_key(&mut decoder, &mut report, &decoded_metadata);
+
+        assert_eq!(report.len(), 0);
+        assert_eq!(cip36.cip36, Some(false));
+        assert_eq!(cip36.voting_keys.len(), 1);
+        assert_eq!(rc, Some(1));
     }
 }

--- a/hermes/crates/cardano-chain-follower/src/metadata/cip36.rs
+++ b/hermes/crates/cardano-chain-follower/src/metadata/cip36.rs
@@ -957,6 +957,24 @@ mod tests {
     }
 
     #[test]
+    fn test_decode_stake_pub_1() {
+        let hex_data = hex::decode(
+            // 0xe3cd2404c84de65f96918f18d5b445bcb933a7cda18eeded7945dd191e432369
+            "5820E3CD2404C84DE65F96918F18D5B445BCB933A7CDA18EEDED7945DD191E432369"
+        ).expect("cannot decode hex");
+        let decoded_metadata = DecodedMetadata(SkipMap::new());
+        let mut cip36 = create_empty_cip36(false);
+        let mut decoder = Decoder::new(&hex_data);
+        let mut report = ValidationReport::new();
+
+        let rc = cip36.decode_stake_pub(&mut decoder, &mut report, &decoded_metadata);
+
+        assert_eq!(report.len(), 0);
+        assert!(cip36.stake_pk.is_some());
+        assert_eq!(rc, Some(1));
+    }
+
+    #[test]
     // cip-36 version
     fn test_decode_voting_key_1() {
         let hex_data = hex::decode(

--- a/hermes/crates/cardano-chain-follower/src/multi_era_block_data.rs
+++ b/hermes/crates/cardano-chain-follower/src/multi_era_block_data.rs
@@ -688,7 +688,7 @@ pub(crate) mod tests {
                 1,
             );
 
-            assert!(block.is_err());
+            assert!(block.is_ok());
         }
     }
 }


### PR DESCRIPTION
# Description

including unit tests for
* [ ] `decode_map_entries` (included in `decode_and_validate`)
* [ ] `decode_map_key` (included in `decode_and_validate`)
* [x] `decode_purpose`
* [x] `decode_nonce`
* [x] `decode_payment_address`
* [ ] `decode_ed25519_pub_key` (included in `decode_stake_pub` and `decode_delegation`)
* [x] `decode_stake_pub`
* [ ] `decode_delegation` (included in `decode_voting_key`)
* [x] `decode_voting_key`

## Related Issue(s)

Closes #338 
