### PR TITLE
feat(hermes): bump wasmtime

### DIFF
--- a/hermes/bin/Cargo.toml
+++ b/hermes/bin/Cargo.toml
@@ -39,7 +39,7 @@ criterion = {version = "0.6.0", optional=true}
 cardano-chain-follower = { path = "../crates/cardano-chain-follower", version = "0.0.1" }
 hermes-ipfs = { version = "0.0.3", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "v0.0.3" }
 
-wasmtime = {version="20.0.2", features = ["component-model"] }
+wasmtime = { version = "33.0.0" }
 rusty_ulid = "2.0.0"
 anyhow = "1.0.89"
 hex-literal = "1.0.0"

--- a/hermes/bin/src/runtime_extensions/bindings.rs
+++ b/hermes/bin/src/runtime_extensions/bindings.rs
@@ -13,4 +13,5 @@ use wasmtime::component::bindgen;
 bindgen!({
     world: "hermes",
     path: "../../wasm/wasi/wit",
+    trappable_imports: true,
 });

--- a/hermes/bin/src/wasm/module.rs
+++ b/hermes/bin/src/wasm/module.rs
@@ -138,7 +138,8 @@ impl Module {
         &self, event: &dyn HermesEventPayload, state: HermesRuntimeContext,
     ) -> anyhow::Result<()> {
         let mut store = WasmStore::new(&self.engine, state);
-        let (instance, _) = bindings::Hermes::instantiate_pre(&mut store, &self.pre_instance)
+        let instance = bindings::HermesPre::new(self.pre_instance.clone())?
+            .instantiate(&mut store)
             .map_err(|e| BadWASMModuleError(e.to_string()))?;
 
         event.execute(&mut ModuleInstance { store, instance })?;

--- a/wasm/wasi/wit/deps/hermes-kv-store/api.wit
+++ b/wasm/wasi/wit/deps/hermes-kv-store/api.wit
@@ -27,7 +27,7 @@ interface api {
       kv-string(string),  // A String
       kv-s64(s64),        // Just use the largest signed integer type supported
       kv-u64(u64),        // Just use the largest integer type supported
-      kv-f64(float64),    // Just use the largest float type supported
+      kv-f64(f64),    // Just use the largest float type supported
       kv-bstr(bstr),      // A byte string
       kv-cbor(cbor),      // CBOR data
       kv-json(json)       // JSON data

--- a/wasm/wasi/wit/deps/hermes-sqlite/api.wit
+++ b/wasm/wasi/wit/deps/hermes-sqlite/api.wit
@@ -50,7 +50,7 @@ interface api {
         /// A blob or a UTF-8 text in bytes.
         blob(list<u8>),
         /// Real number.
-        double(float64),
+        double(f64),
         /// 32-bit integer.
         int32(s32),
         /// 64-bit integer.


### PR DESCRIPTION
# Description

Bump `wasmtime` from `20.0.2` to `33.0.0`

## Related Issue

Closes #404

## Description of Changes

- Bump dependency version. Remove explicit "component-model" feature as it's a "default" feature now.
- Update `.wit` files to the newer `wasmtime` requirements.
- Update `bindgen!` syntax.
- Update instantiation syntax

## Breaking Changes

None.

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
