### PR TITLE
feat(general): add ci jobs to sync labels

### DIFF
--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,13 @@
+name: Sync labels from catalyst-ci
+
+on:
+  workflow_dispatch:
+  repository_dispatch:
+    types: [catalyst-labels-updated]
+
+permissions:
+  issues: write
+
+jobs:
+  sync:
+    uses: input-output-hk/catalyst-ci/.github/workflows/sync-labels.yml@master


### PR DESCRIPTION
- Add CI job to sync labels from `catalyst-ci`