### PR TITLE
feat(rust): Hermes done

### DIFF
--- a/.config/dictionaries/project.dic
+++ b/.config/dictionaries/project.dic
@@ -28,6 +28,7 @@ cids
 ciphertext
 codegen
 codepoints
+Condvar
 coti
 coverallsapp
 cpus
@@ -153,7 +154,6 @@ pubk
 pubkey
 pubspec
 pwrite
-rustls
 qpsg
 quic
 rapidoc
@@ -170,6 +170,7 @@ rustdoc
 rustdocflags
 rustflags
 rustfmt
+rustls
 rustyline
 saibatizoku
 sandboxed

--- a/hermes/bin/src/cli/mod.rs
+++ b/hermes/bin/src/cli/mod.rs
@@ -78,7 +78,10 @@ impl Cli {
         logger::init(&log_config).unwrap_or_else(errors.get_add_err_fn());
 
         match self.command {
-            Commands::Run(cmd) => cmd.exec(),
+            Commands::Run(cmd) => {
+                cmd.exec()
+                    .map(|exit| println!("{}:\n{}", Emoji::new("⛔", "Exit"), style(exit).red()))
+            },
             Commands::Module(cmd) => cmd.exec(),
             Commands::App(cmd) => cmd.exec(),
         }

--- a/hermes/bin/src/cli/run.rs
+++ b/hermes/bin/src/cli/run.rs
@@ -1,12 +1,13 @@
 //! Run cli command
 
-use std::path::PathBuf;
+use std::{path::PathBuf, time::Duration};
 
 use clap::Args;
 use console::Emoji;
 
 use crate::{
     cli::Cli,
+    event::queue::Exit,
     ipfs,
     packaging::{
         app::{build_app, ApplicationPackage},
@@ -28,12 +29,16 @@ pub(crate) struct Run {
     /// Flag which disables package signature verification
     #[clap(long, action = clap::ArgAction::SetTrue)]
     untrusted: bool,
+
+    /// Shutdown an application after the timeout (milliseconds)
+    #[arg(long)]
+    timeout_ms: Option<u64>,
 }
 
 impl Run {
     #[allow(unreachable_code)]
     /// Run the hermes application
-    pub(crate) fn exec(self) -> anyhow::Result<()> {
+    pub(crate) fn exec(self) -> anyhow::Result<Exit> {
         for cert_path in self.certificates {
             let cert = Certificate::from_file(cert_path)?;
             certificate::storage::add_certificate(cert)?;
@@ -50,19 +55,20 @@ impl Run {
         ipfs::bootstrap(hermes_home_dir.as_path(), default_bootstrap)?;
         let app = build_app(&package, hermes_home_dir)?;
 
-        reactor::init()?;
+        let exit_lock = reactor::init()?;
         println!(
             "{} Loading application {}...",
             Emoji::new("🛠️", ""),
             app.name()
         );
         reactor::load_app(app)?;
-        std::thread::yield_now();
 
-        // TODO[RC]: Temporary hack to keep the reactor running.
-        #[allow(clippy::empty_loop)]
-        loop {}
+        let exit = if let Some(timeout_ms) = self.timeout_ms {
+            exit_lock.wait_timeout(Duration::from_millis(timeout_ms))
+        } else {
+            exit_lock.wait()
+        };
 
-        Ok(())
+        Ok(exit)
     }
 }

--- a/hermes/bin/src/event/queue/exit.rs
+++ b/hermes/bin/src/event/queue/exit.rs
@@ -1,0 +1,95 @@
+//! Implementation of exit status retrieval after event queue shutdown.
+
+use std::{
+    sync::{Arc, Condvar, Mutex},
+    time::Duration,
+};
+
+/// Exit code to return after queue shutdown.
+pub type ExitCode = i64;
+
+/// Exit status.
+#[derive(Copy, Clone, PartialEq, Eq, Debug, thiserror::Error)]
+pub enum Exit {
+    /// An application requested runtime abort.
+    #[error(
+        "Event queue closed: an application requested runtime abort with exit code {exit_code}"
+    )]
+    Done {
+        /// Exit code provided by an application.
+        exit_code: ExitCode,
+    },
+    /// All event senders are dropped.
+    #[error("Event queue closed: all event senders are dropped")]
+    QueueClosed,
+    /// Another task panicked inside.
+    #[error("Event queue poisoned: another task panicked inside")]
+    QueuePoisoned,
+    /// Timeout elapsed.
+    #[error("Event queue closed: timeout")]
+    Timeout,
+}
+
+/// Lock to [`Exit`] that event queue sets on shutdown.
+// To satisfy the guarantees [`ExitLock`] should never implement or derive `Clone`.
+pub struct ExitLock(Arc<(Condvar, Mutex<Option<Exit>>)>);
+
+impl ExitLock {
+    /// Initializes the lock and return two clones of it.
+    pub(super) fn new_pair() -> (Self, Self) {
+        let condvar = Condvar::new();
+        // Default value doesn't matter as it's bound to be awaited to be changed.
+        let payload = Mutex::new(None);
+        let inner = Arc::new((condvar, payload));
+        (Self(inner.clone()), Self(inner))
+    }
+
+    /// Set the [`Exit`] value. This will notify the waiting thread.
+    ///
+    /// This shouldn't exposed the waiting thread.
+    pub(super) fn set(self, exit: Exit) {
+        let (condvar, payload) = &*self.0;
+        // It doesn't matter if the lock is poisoned
+        // because the condvar would catch it anyway.
+        let Ok(mut payload) = payload.lock() else {
+            return;
+        };
+        payload.get_or_insert(exit);
+        condvar.notify_one();
+    }
+
+    /// Blocks until the [`Exit`] value is set.
+    pub fn wait(self) -> Exit {
+        let (condvar, payload) = &*self.0;
+        let Ok(exit) = payload.lock() else {
+            return Exit::QueuePoisoned;
+        };
+        condvar
+            .wait_while(exit, |opt| opt.is_none())
+            .as_deref()
+            .copied()
+            .unwrap_or(Some(Exit::QueuePoisoned))
+            // `None` is guaranteed to be unreachable since we are waiting for `Some` on condvar.
+            .unwrap_or(Exit::QueuePoisoned)
+    }
+
+    /// Blocks until either the [`Exit`] value is set or the timeout elapses.
+    pub fn wait_timeout(self, dur: Duration) -> Exit {
+        let (condvar, payload) = &*self.0;
+        let Ok(exit) = payload.lock() else {
+            return Exit::QueuePoisoned;
+        };
+        condvar
+            .wait_timeout_while(exit, dur, |opt| opt.is_none())
+            .map(|(exit, timeout)| {
+                if timeout.timed_out() {
+                    Some(Exit::Timeout)
+                } else {
+                    *exit
+                }
+            })
+            .unwrap_or(Some(Exit::QueuePoisoned))
+            // `None` is guaranteed to be unreachable since we are waiting for `Some` on condvar.
+            .unwrap_or(Exit::QueuePoisoned)
+    }
+}

--- a/hermes/bin/src/reactor.rs
+++ b/hermes/bin/src/reactor.rs
@@ -5,7 +5,7 @@ use once_cell::sync::OnceCell;
 
 use crate::{
     app::{Application, ApplicationName},
-    event,
+    event::{self, queue::ExitLock},
     runtime_extensions::hermes::init,
 };
 
@@ -31,8 +31,10 @@ struct Reactor {
 
 /// Initialize Hermes Reactor.
 /// Setup and runs all necessary services.
-pub(crate) fn init() -> anyhow::Result<()> {
-    event::queue::init()?;
+///
+/// [`ExitLock`] would contain shutdown information if awaited.
+pub(crate) fn init() -> anyhow::Result<ExitLock> {
+    let exit_lock = event::queue::init()?;
 
     REACTOR_STATE
         .set(Reactor {
@@ -40,7 +42,7 @@ pub(crate) fn init() -> anyhow::Result<()> {
         })
         .map_err(|_| AlreadyInitializedError)?;
 
-    Ok(())
+    Ok(exit_lock)
 }
 
 /// Load Hermes application into the Hermes Reactor.

--- a/hermes/bin/src/runtime_extensions/hermes/init/host.rs
+++ b/hermes/bin/src/runtime_extensions/hermes/init/host.rs
@@ -1,0 +1,12 @@
+//! Hermes Init host implementation for WASM runtime.
+use crate::{
+    event, runtime_context::HermesRuntimeContext,
+    runtime_extensions::bindings::hermes::init::api::Host,
+};
+
+impl Host for HermesRuntimeContext {
+    /// Perform Hermes event queue shut down.
+    fn done(&mut self, exit_code: i64) -> wasmtime::Result<()> {
+        event::queue::shutdown(exit_code)
+    }
+}

--- a/hermes/bin/src/runtime_extensions/hermes/init/mod.rs
+++ b/hermes/bin/src/runtime_extensions/hermes/init/mod.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 
 mod event;
+mod host;
 
 /// Advise Runtime Extensions of a new context
 pub(crate) fn new_context(_ctx: &crate::runtime_context::HermesRuntimeContext) {}

--- a/wasm/wasi/wit/deps/hermes-init/api.wit
+++ b/wasm/wasi/wit/deps/hermes-init/api.wit
@@ -1,0 +1,10 @@
+/// # Interface to Hermes runtime control flow.
+///
+/// ## Permissions
+///
+/// This API is ONLY Available to Integration Tests and is not normally exposed.
+
+interface api {
+    /// Perform Hermes event queue shut down.
+    done: func(exit-code: s64);
+}

--- a/wasm/wasi/wit/deps/hermes-init/world.wit
+++ b/wasm/wasi/wit/deps/hermes-init/world.wit
@@ -1,5 +1,7 @@
 package hermes:init;
 
 world all {
+    import api;
+
     export event;
 }


### PR DESCRIPTION
# Description

Implements support for shutting down Hermes.

## Related Issue(s)

Closes #447

## Description of Changes

- New `Exit` type descrIbing status of the Hermes shutdown.
- New `ExitLock` type. Can be used to wait until the event queue is shut down.
- Event queue now receives events wrapped in `ControlFlow::Continue`
  - Sending `ControlFlow::Break(exit_code)` to queue is used as a manual shutdown.
- Added `event::queue::shutdown(exit_code)` function.
- Updated CLI `run` command.
  - Now printing the exit status.
  - Replace `yield_now() + loop {}` with `Condvar` waiting (wrapped in `ExitLock`).
  - Add `--timeout-ms` argument.
- Add `done` function to `hermes-init` WIT world.
- Add  `Host` implementation for `done` that shuts down the node.

## Breaking Changes

Security is majorly hurt. After this PR any application would be able to shut down the whole node.
A solution would be to gate both `done` fn and `integration-test` world behind WIT feature(s) in WIT files.
These features can then be toggled in Hermes `LinkOptions` trivially.

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
