### PR TITLE
chore(general): Enable ci local run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,10 @@ jobs:
     uses: input-output-hk/catalyst-forge/.github/workflows/ci.yml@ci/v1.7.2
     with:
       forge_version: 0.8.0
+      local: true
 
-  test_reporting:
-    if: ${{ !github.event.pull_request.draft }}
-    needs: ci
-    uses: ./.github/workflows/generate-allure-report.yml
+  # TODO: Enable when our earthly self-satellites will be back and remove `local: true` flag
+  # test_reporting:
+  #   if: ${{ !github.event.pull_request.draft }}
+  #   needs: ci
+  #   uses: ./.github/workflows/generate-allure-report.yml

--- a/blueprint.cue
+++ b/blueprint.cue
@@ -23,11 +23,6 @@ global: {
 			}
 
 			earthly: {
-				credentials: {
-					provider: "aws"
-					path:     "global/ci/earthly"
-				}
-				org:       "Catalyst"
 				satellite: "ci"
 				version:   "0.8.15"
 			}


### PR DESCRIPTION
Enable CI local run.

This should be reverted once earthly satellite is back or any other solution is properly implemented.