### PR TITLE
ci(general): add project fields validation

### DIFF
--- a/.github/workflows/validate-project-fields.yml
+++ b/.github/workflows/validate-project-fields.yml
@@ -1,0 +1,20 @@
+name: Validate Project Fields
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
+  repository-projects: write
+
+jobs:
+  validate-project-fields:
+    uses: input-output-hk/catalyst-ci/.github/workflows/validate-project-fields.yml@master
+    secrets: inherit


### PR DESCRIPTION
- Add workflow for project fields validation to ensure the repository follows our project management standards.

> Note for the reviewer: The script automatically assigns PRs to the PR creator using the GitHub REST API, which requires write permissions.