### PR TITLE
fix(general): Bump rust ci to v3.5.6

### DIFF
--- a/hermes/Earthfile
+++ b/hermes/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.5.4 AS rust-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.5.6 AS rust-ci
 # Use when debugging cat-ci locally.
 # IMPORT ../../catalyst-ci/earthly/rust AS rust-ci
 

--- a/wasm/examples/rust/cardano/Earthfile
+++ b/wasm/examples/rust/cardano/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.5.4 AS rust-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.5.6 AS rust-ci
 # Use when debugging cat-ci locally.
 # IMPORT ../../../catalyst-ci/earthly/rust AS rust-ci
 

--- a/wasm/examples/rust/cardano_age/Earthfile
+++ b/wasm/examples/rust/cardano_age/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.5.4 AS rust-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.5.6 AS rust-ci
 # Use when debugging cat-ci locally.
 # IMPORT ../../../catalyst-ci/earthly/rust AS rust-ci
 

--- a/wasm/examples/rust/next_century/Earthfile
+++ b/wasm/examples/rust/next_century/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.5.4 AS rust-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.5.6 AS rust-ci
 # Use when debugging cat-ci locally.
 # IMPORT ../../../catalyst-ci/earthly/rust AS rust-ci
 

--- a/wasm/integration-test/cardano/Earthfile
+++ b/wasm/integration-test/cardano/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.5.4 AS rust-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.5.6 AS rust-ci
 # Use when debugging cat-ci locally.
 # IMPORT ../../catalyst-ci/earthly/rust AS rust-ci
 

--- a/wasm/integration-test/http_reply/Earthfile
+++ b/wasm/integration-test/http_reply/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.5.4 AS rust-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.5.6 AS rust-ci
 # Use when debugging cat-ci locally.
 # IMPORT ../../catalyst-ci/earthly/rust AS rust-ci
 

--- a/wasm/integration-test/ipfs/Earthfile
+++ b/wasm/integration-test/ipfs/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.5.4 AS rust-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.5.6 AS rust-ci
 # Use when debugging cat-ci locally.
 # IMPORT ../../catalyst-ci/earthly/rust AS rust-ci
 

--- a/wasm/integration-test/sqlite/Earthfile
+++ b/wasm/integration-test/sqlite/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.5.4 AS rust-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.5.6 AS rust-ci
 # Use when debugging cat-ci locally.
 # IMPORT ../../catalyst-ci/earthly/rust AS rust-ci
 

--- a/wasm/integration-test/wasi-filesystem/Earthfile
+++ b/wasm/integration-test/wasi-filesystem/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.5.4 AS rust-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.5.6 AS rust-ci
 # Use when debugging cat-ci locally.
 # IMPORT ../../catalyst-ci/earthly/rust AS rust-ci
 

--- a/wasm/wasi/Earthfile
+++ b/wasm/wasi/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.5.4 AS rust-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.5.6 AS rust-ci
 IMPORT github.com/input-output-hk/catalyst-ci/earthly/go:v3.5.4 AS go-ci
 
 # Use when debugging cat-ci locally.


### PR DESCRIPTION
# Description
 
Bump rust-ci from v3.5.4 to v3.5.6

This will solve `libc header file not found`  for zstd direct or transitive dependency.
