### PR TITLE
feat(hermes): Add `get-fork` for block resource in cardano

### DIFF
--- a/hermes/bin/src/runtime_extensions/hermes/cardano/network.rs
+++ b/hermes/bin/src/runtime_extensions/hermes/cardano/network.rs
@@ -70,7 +70,7 @@ pub(crate) fn spawn_subscribe(
                 "Failed to spawn chain follower"
             );
             return;
-        }; // // Hold onto the clone inside the thread to keep Arc alive
+        };
 
         rt.block_on(subscribe(
             cmd_rx,

--- a/wasm/examples/rust/cardano/src/lib.rs
+++ b/wasm/examples/rust/cardano/src/lib.rs
@@ -15,6 +15,7 @@ impl hermes::exports::hermes::cardano::event_on_block::Guest for TestComponent {
         let is_immutable = block.is_immutable();
         let is_rollback = block.is_rollback();
         let network = subscription_id.get_network();
+        let fork = block.get_fork();
         if let Ok(txn) = block.get_txn(0) {
             txn_hash = txn.get_txn_hash();
         }
@@ -26,7 +27,7 @@ impl hermes::exports::hermes::cardano::event_on_block::Guest for TestComponent {
             None,
             None,
             None,
-            format!("✈️ - on_cardano_block event trigger - subscription ID: {subscription_id:?}, network: {network:?}, slot: {slot:?}, is rollback: {is_rollback:?}, is immutable: {is_immutable}, txn hash: {txn_hash:?}").as_str(),
+            format!("✈️ - on_cardano_block event trigger - subscription ID: {subscription_id:?}, network: {network:?}, slot: {slot:?}, is rollback: {is_rollback:?}, is immutable: {is_immutable}, txn hash: {txn_hash:?}, fork: {fork:?}").as_str(),
             None,
         );
     }

--- a/wasm/wasi/wit/deps/hermes-cardano/api.wit
+++ b/wasm/wasi/wit/deps/hermes-cardano/api.wit
@@ -198,6 +198,23 @@ interface api {
         ///
         /// - `cbor` : The CBOR format of the block.
         raw: func() -> cbor;
+
+        /// Fork count is a counter that is incremented every time there is a roll-back in
+        /// live-chain. It is used to help followers determine how far to roll-back to
+        /// resynchronize without storing full block history. The fork count starts at 1 for
+        /// live blocks and increments if the live chain tip is purged due to a detected
+        /// fork, but it does not track the exact number of forks reported by peers.
+        ///
+        /// - 0 - for all immutable data
+        /// - 1 - for any data read from the blockchain during a *backfill* on initial sync
+        /// - 2+ - for each subsequent rollback detected while reading live blocks.
+        ///
+        /// Note: This fork terminology is different from fork in blockchain.
+        ///
+        /// ** Returns **
+        ///
+        /// - `u64` : The fork count.
+        get-fork: func() -> u64;
     }
 
     /// Cardano transaction


### PR DESCRIPTION
# Description

Add `get-fork` function for block resource.
This fork number is needed for creating a  [MultiEraBlock](https://github.com/input-output-hk/catalyst-libs/blob/93fd483150e2ecaf279e960fc8baf2d8babb875f/rust/cardano-blockchain-types/src/multi_era_block_data.rs#L96) that will be used later for getting RBAC registration

## Related Issue(s)

https://github.com/input-output-hk/hermes/issues/460


## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
