### PR TITLE
feat(hermes): Add utilities for regex sorting and integer macc operations

### DIFF
--- a/.config/dictionaries/project.dic
+++ b/.config/dictionaries/project.dic
@@ -16,6 +16,7 @@ bootstrapper
 BROTLI
 cantopen
 cardano
+catfact
 cbor
 cbork
 cdylib
@@ -47,6 +48,7 @@ dockerhub
 dotenv
 dotenvy
 dotglob
+DOTSTAR
 drep
 dreps
 Earthfile
@@ -94,6 +96,7 @@ jorm
 jormungandr
 Jörmungandr
 jsonschema
+justfile
 lcov
 Leshiy
 libipld
@@ -150,12 +153,13 @@ preopen
 preopened
 preopens
 preprod
+projectcatalyst
 psql
 pubk
 pubkey
 pubspec
 pwrite
-rustls
+QMARK
 qpsg
 quic
 rafal
@@ -165,8 +169,8 @@ redoc
 reloc
 REMOVEDIR
 renameat
-retriggering
 reqwest
+retriggering
 rngs
 rulelist
 rulename
@@ -176,9 +180,11 @@ rustdocflags
 rustflags
 rustfmt
 rustls
+rustup
 rustyline
 saibatizoku
 sandboxed
+sandboxing
 scanorder
 scanstatus
 Sched
@@ -207,6 +213,7 @@ tinygo
 toobig
 toolsets
 Traceback
+tweakable
 txns
 typenum
 unfinalized
@@ -231,10 +238,3 @@ xpub
 yamux
 yoroi
 zstack
-reqwest
-projectcatalyst
-yamux
-justfile
-sandboxing
-catfact
-rustup

--- a/hermes/Cargo.lock
+++ b/hermes/Cargo.lock
@@ -1032,7 +1032,7 @@ source = "git+https://github.com/input-output-hk/catalyst-libs.git?tag=cardano-b
 dependencies = [
  "anyhow",
  "blake2b_simd",
- "catalyst-types",
+ "catalyst-types 0.0.5",
  "cbork-utils",
  "chrono",
  "dashmap",
@@ -1058,7 +1058,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "cardano-blockchain-types",
- "catalyst-types",
+ "catalyst-types 0.0.5",
  "chrono",
  "cpu-time",
  "crossbeam-channel",
@@ -1154,6 +1154,27 @@ dependencies = [
  "num-traits",
  "orx-concurrent-vec",
  "pallas-crypto 0.33.0",
+ "serde",
+ "strum 0.27.2",
+ "thiserror 2.0.12",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "catalyst-types"
+version = "0.0.6"
+source = "git+https://github.com/input-output-hk/catalyst-libs.git?tag=catalyst-types-v0.0.6#600f8462cf5ba4d17bf5f91a4e14da911912f026"
+dependencies = [
+ "base64-url",
+ "chrono",
+ "displaydoc",
+ "ed25519-dalek",
+ "fluent-uri",
+ "fmmap",
+ "minicbor",
+ "num-traits",
+ "orx-concurrent-vec",
  "serde",
  "strum 0.27.2",
  "thiserror 2.0.12",
@@ -3010,6 +3031,7 @@ dependencies = [
  "build-info-build",
  "cardano-blockchain-types",
  "cardano-chain-follower",
+ "catalyst-types 0.0.6",
  "chrono",
  "chrono-tz",
  "clap",
@@ -3035,6 +3057,7 @@ dependencies = [
  "jsonschema",
  "libsqlite3-sys",
  "libtest-mimic",
+ "num-traits",
  "num_cpus",
  "once_cell",
  "pbkdf2",

--- a/hermes/bin/Cargo.toml
+++ b/hermes/bin/Cargo.toml
@@ -34,6 +34,7 @@ path = "tests/integration/tests/mod.rs"
 hermes-ipfs = { version = "0.0.5", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "hermes-ipfs/v0.0.5" }
 cardano-blockchain-types = { version = "0.0.5", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "cardano-blockchain-types-v0.0.5" }
 cardano-chain-follower = { version = "0.0.11", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "cardano-chain-follower-v0.0.11" }
+catalyst-types = { version = "0.0.6", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "catalyst-types-v0.0.6" }
 
 # HDF5 is consumed using a git tag, because the latest release is very old, but the code is much more advanced.
 hdf5 = { package = "hdf5-metno", version = "0.10.1", features = [ "static", "blosc", "blosc-zstd" ] }
@@ -92,6 +93,7 @@ usvg = "0.45.1"
 uuid = { version = "1.17.0", features = ["v4"] }
 reqwest = "0.12.22"
 url = "2.5.4"
+num-traits = "0.2.19"
 
 [build-dependencies]
 build-info-build = "0.0.41"

--- a/hermes/bin/src/runtime_extensions/utils/mod.rs
+++ b/hermes/bin/src/runtime_extensions/utils/mod.rs
@@ -1,3 +1,5 @@
 //! Hermes runtime extensions utilities.
 
 pub(crate) mod conversion;
+pub(crate) mod mul_add;
+pub(crate) mod regex_ranking;

--- a/hermes/bin/src/runtime_extensions/utils/mul_add.rs
+++ b/hermes/bin/src/runtime_extensions/utils/mul_add.rs
@@ -1,0 +1,97 @@
+//! Signed Integer Multiply and
+
+use catalyst_types::conversion::from_saturating;
+
+/// A trait providing a saturating multiply-accumulate:
+///
+/// `self + (y * z)` with saturating arithmetic, updating `Self`.
+///
+/// `self` is the Accumulator, and can be any integer but will saturate at max i128 if
+/// its a `u128` or larger.  Otherwise it will saturate within the bounds of its type.
+///
+/// `y` and `z` can be any integer type.
+///
+/// Works across any combination of integer types (signed or unsigned).
+pub trait SaturatingMulAdd<U, V> {
+    /// Multiply and Accumulate Integers.
+    fn mul_add(
+        &mut self,
+        y: U,
+        z: V,
+    );
+}
+
+/// Implement the trait for various integer types.
+macro_rules! impl_saturating_mul_add {
+    ($($t:ty),*) => {
+        $(
+            impl<U, V> SaturatingMulAdd<U, V> for $t
+            where
+                U: Copy
+                    + TryInto<i128>
+                    + std::ops::Sub<Output = U>
+                    + std::cmp::PartialOrd<U>
+                    + num_traits::identities::Zero,
+                V: Copy
+                    + TryInto<i128>
+                    + std::ops::Sub<Output = V>
+                    + std::cmp::PartialOrd<V>
+                    + num_traits::identities::Zero,
+            {
+                fn mul_add(&mut self, y: U, z: V) {
+                    let self128: i128 = from_saturating(*self);
+                    let y128:i128 = from_saturating(y);
+                    let z128:i128 = from_saturating(z);
+
+                    *self = from_saturating(z128.saturating_mul(y128).saturating_add(self128));
+                }
+            }
+        )*
+    };
+}
+
+// Implement for all signed integer types
+impl_saturating_mul_add!(i8, i16, i32, i64, i128, isize);
+// Implement for all unsigned integer types
+impl_saturating_mul_add!(u8, u16, u32, u64, usize);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn i32_u64_i8() {
+        let mut s: i32 = 5;
+        let y: u128 = 10;
+        let z: i8 = -3;
+        s.mul_add(y, z);
+        assert_eq!(s, -25);
+    }
+
+    #[test]
+    fn u8_i64_u128_pos() {
+        let mut s: u8 = 5;
+        let y: i64 = 10000;
+        let z: u128 = 1_234_567;
+        s.mul_add(y, z);
+        assert_eq!(s, 255);
+    }
+
+    #[test]
+    fn u8_i64_u128_neg() {
+        let mut s: u8 = 5;
+        let y: i64 = -10000;
+        let z: u128 = 1_234_567;
+        s.mul_add(y, z);
+        assert_eq!(s, 0);
+    }
+
+    #[test]
+    fn i16_i64_u128_neg() {
+        let mut s: i16 = 5;
+        let y: i64 = -10000;
+        let z: u128 = 1_234_567;
+        s.mul_add(y, z);
+        assert_eq!(s, -32768);
+    }
+}

--- a/hermes/bin/src/runtime_extensions/utils/regex_ranking.rs
+++ b/hermes/bin/src/runtime_extensions/utils/regex_ranking.rs
@@ -1,0 +1,162 @@
+//! Regex Specificity Scoring and Sorting
+//!
+//! This module provides functionality to heuristically score and sort
+//! regular expressions by their "specificity."
+//!
+//! ### Specificity Heuristics
+//! - **More literal characters → more specific**
+//! - **Anchors (`^`, `$`) → more specific**
+//! - **Exact quantifiers (`{n}`) → more specific**
+//! - **Wildcards (`.`, `.*`) and open quantifiers (`+`, `*`, `?`) → less specific**
+//! - **Alternation (`|`) → less specific**
+//!
+//! ⚠️ Note: This is **heuristic-based**. Regex semantics can be arbitrarily
+//! complex, so this does not guarantee mathematically correct ordering,
+//! but is usually good enough for routing/matching use cases.
+
+use std::sync::LazyLock;
+
+use catalyst_types::conversion::from_saturating;
+use regex::Regex;
+
+use crate::runtime_extensions::utils::mul_add::SaturatingMulAdd;
+
+// Scoring weights (tweakable constants).
+/// Weight of an alphanumeric literal
+const LITERAL_WEIGHT: i32 = 1;
+/// Weight of an Anchor (`^` or `$`) in the Regex
+const ANCHOR_WEIGHT: i32 = 5;
+/// Weight of a single `.` in the Regex
+const DOT_WEIGHT: i32 = -2;
+/// Weight of a `.*` in the Regex
+const DOTSTAR_WEIGHT: i32 = -10;
+/// Weight of a `+` in the Regex
+const PLUS_WEIGHT: i32 = -11;
+/// Weight of a `*` in the Regex
+const STAR_WEIGHT: i32 = -3;
+/// Weight of a `?` in the Regex
+const QMARK_WEIGHT: i32 = -2;
+/// Weight of a quantifier (`{n}`) in the Regex
+const EXACT_QUANT_WEIGHT: i32 = 4;
+
+/// Regex used to match and count exact number of quantifiers in a regex.
+static EXACT_QUANT: LazyLock<Regex> = LazyLock::new(|| {
+    #[allow(clippy::unwrap_used)]
+    Regex::new(r"\{\d+\}").unwrap()
+});
+
+/// Compute a "specificity score" for a regex string.
+/// Higher scores mean the regex is considered more specific.
+/// `input` is anything that can be converted to a string reference.
+#[allow(dead_code)]
+pub(crate) fn regex_specificity_score<T: AsRef<str>>(input: T) -> i32 {
+    let re = input.as_ref();
+
+    let mut score: i32 = 0;
+
+    // split on alternations, if present, and weight them distinctly, and use the total of weights
+    // divided by the number of alternations.
+    // Theory being the specificity is the average of all the alternatives specificity.
+    //let alts = re.bytes().filter(|c| *c == b'|').count();
+    let alts: Vec<&str> = re.split('|').collect();
+    let alts_len = alts.len();
+    if alts_len > 1 {
+        for x in alts {
+            score.mul_add(1, regex_specificity_score(x));
+        }
+        #[allow(clippy::arithmetic_side_effects)]
+        return score.saturating_div(from_saturating(alts_len));
+    }
+
+    // Count literal (alphanumeric) characters
+    score.mul_add(
+        re.chars().filter(|c| c.is_alphanumeric()).count(),
+        LITERAL_WEIGHT,
+    );
+
+    // Anchors
+    if re.contains('^') {
+        score.mul_add(1, ANCHOR_WEIGHT);
+    }
+    if re.contains('$') {
+        score.mul_add(1, ANCHOR_WEIGHT);
+    }
+
+    // Wildcards
+    let dot_stars = re.matches(".*").count();
+    if dot_stars > 0 {
+        score.mul_add(dot_stars, DOTSTAR_WEIGHT);
+    } else {
+        score.mul_add(re.matches('.').count(), DOT_WEIGHT);
+    }
+
+    // Quantifiers
+    score.mul_add(re.matches('+').count(), PLUS_WEIGHT);
+    score.mul_add(re.matches('*').count(), STAR_WEIGHT);
+    score.mul_add(re.matches('?').count(), QMARK_WEIGHT);
+
+    // Exact quantifiers `{n}`
+    score.mul_add(EXACT_QUANT.find_iter(re).count(), EXACT_QUANT_WEIGHT);
+
+    score
+}
+
+/// Sort a list of regex strings from most specific to least specific.
+#[allow(dead_code)]
+pub(crate) fn sort_regexes_by_specificity<T: AsRef<str>>(regexes: Vec<T>) -> Vec<T> {
+    let mut scored: Vec<_> = regexes
+        .into_iter()
+        .map(|re| (regex_specificity_score(&re), re))
+        .collect();
+
+    // Sort descending by score (most specific first)
+    scored.sort_by(|a, b| b.0.cmp(&a.0));
+
+    scored.into_iter().map(|(_score, re)| re).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_literal_specificity() {
+        let s1 = regex_specificity_score("hello");
+        let s2 = regex_specificity_score(".*");
+        assert!(s1 > s2, "Literal should be more specific than wildcard");
+    }
+
+    #[test]
+    fn test_anchor_bonus() {
+        let anchored = regex_specificity_score("^abc$");
+        let unanchored = regex_specificity_score("abc");
+        assert!(anchored > unanchored, "Anchored regex should score higher");
+    }
+
+    #[test]
+    fn test_quantifiers() {
+        let exact = regex_specificity_score(r"a{5}");
+        let open = regex_specificity_score(r"a+");
+        assert!(exact > open, "Exact quantifier should be more specific");
+    }
+
+    #[test]
+    fn test_alternation_penalty() {
+        let alt = regex_specificity_score("a|b|c");
+        let literal = regex_specificity_score("abc");
+        assert!(
+            literal > alt,
+            "Literal sequence should be more specific than alternation"
+        );
+    }
+
+    #[test]
+    fn test_sorting_order() {
+        let regexes = vec![r".*", r"^hello$", r"abc\d+", r"^foo.*bar$", r"a|b|c"];
+        let expected = vec![r"^hello$", r"^foo.*bar$", r"a|b|c", r"abc\d+", r".*"];
+
+        let sorted = sort_regexes_by_specificity(regexes);
+
+        assert_eq!(sorted, expected);
+    }
+}


### PR DESCRIPTION

# Description

Utility functions we will use in later tasks.

## Related Issue(s)

Part Of: https://github.com/input-output-hk/catalyst-internal-docs/issues/292

## Description of Changes

Adds utility functions which are currently unused.

## Breaking Changes

None

## Screenshots

N/A

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
