### PR TITLE
feat(hermes): parallel sql processing

### DIFF
--- a/.config/dictionaries/project.dic
+++ b/.config/dictionaries/project.dic
@@ -135,6 +135,7 @@ nbaz
 netkey
 nextest
 nolfs
+nomutex
 nostack
 notadb
 nsec
@@ -215,6 +216,7 @@ testdocs
 testunit
 thiserror
 thollander
+threadsafe
 timelike
 timespec
 tinygo

--- a/.config/dictionaries/project.dic
+++ b/.config/dictionaries/project.dic
@@ -7,6 +7,7 @@ aido-mth
 apskhem
 asat
 asyncio
+autocheckpoint
 auditability
 backpressure
 bindgen

--- a/hermes/bin/src/runtime_extensions/hermes/sqlite/connection/core.rs
+++ b/hermes/bin/src/runtime_extensions/hermes/sqlite/connection/core.rs
@@ -260,8 +260,11 @@ mod tests {
             close(db_ptr).expect("failed to close connection");
         }
 
-        let uuid = uuid::Uuid::new_v4().to_string();
-        let db_ptr = init_fs(uuid.clone()).unwrap();
+        // Running db in memory and in file mode at the same time
+        // causes issues during test run
+        const APP_NAME: &str = "counter-app";
+
+        let db_ptr = init_fs(APP_NAME.to_string()).unwrap();
         execute(
             db_ptr,
             r"
@@ -276,7 +279,7 @@ mod tests {
 
         let mut handlers = vec![];
         for _ in 0..100 {
-            let app_name = uuid.clone();
+            let app_name = APP_NAME.to_string();
             handlers.push(std::thread::spawn(move || task(app_name)));
         }
 

--- a/hermes/bin/src/runtime_extensions/hermes/sqlite/connection/core.rs
+++ b/hermes/bin/src/runtime_extensions/hermes/sqlite/connection/core.rs
@@ -109,7 +109,13 @@ mod tests {
     use super::*;
     use crate::{
         app::ApplicationName,
-        runtime_extensions::hermes::sqlite::{core::open, statement::core::finalize},
+        runtime_extensions::{
+            bindings::hermes::sqlite::api::Value,
+            hermes::sqlite::{
+                core::open,
+                statement::core::{column, finalize, step},
+            },
+        },
     };
 
     const TMP_DIR: &str = "tmp-dir";
@@ -118,6 +124,12 @@ mod tests {
         let app_name = ApplicationName(String::from(TMP_DIR));
 
         open(false, true, app_name)
+    }
+
+    fn init_fs() -> Result<*mut sqlite3, Errno> {
+        let app_name = ApplicationName(String::from(TMP_DIR));
+
+        open(false, false, app_name)
     }
 
     #[test]
@@ -225,5 +237,49 @@ mod tests {
         let db_ptr = init().unwrap();
 
         close(db_ptr).unwrap();
+    }
+
+    #[test]
+    fn test_multiple_threads_does_not_conflict() {
+        fn task() {
+            let db_ptr = init_fs().unwrap();
+            let statement = prepare(
+                db_ptr,
+                r"
+                    UPDATE counter
+                    SET value = value + 1
+                    RETURNING value;
+                ",
+            )
+            .expect("failed to prepare statement");
+            step(statement).expect("failed to make a step");
+            let Value::Int32(_counter) = column(statement, 0).expect("failed to get value") else {
+                panic!("invalid type");
+            };
+            finalize(statement).expect("failed to finalize statement");
+            close(db_ptr).expect("failed to close connection");
+        }
+
+        let db_ptr = init_fs().unwrap();
+        execute(
+            db_ptr,
+            r"
+                CREATE TABLE IF NOT EXISTS counter (
+                    value INTEGER
+                );
+                ",
+        )
+        .expect("failed to create  table");
+        execute(db_ptr, "INSERT INTO counter(value) VALUES(0);").expect("failed to insert value");
+        close(db_ptr).expect("failed to close connection");
+
+        let mut handlers = vec![];
+        for _ in 0..100 {
+            handlers.push(std::thread::spawn(task));
+        }
+
+        for handler in handlers {
+            handler.join().expect("failed to join handler");
+        }
     }
 }

--- a/hermes/bin/src/runtime_extensions/hermes/sqlite/core.rs
+++ b/hermes/bin/src/runtime_extensions/hermes/sqlite/core.rs
@@ -163,7 +163,7 @@ pub(super) fn open(
     }
 
     if !memory && !readonly {
-        // TODO(anyone): fix issue with locks during hermes app execution
+        // TODO(anyone): fix issue with locks during hermes app execution https://github.com/input-output-hk/hermes/issues/521
         // enable_wal_mode(db_ptr)?;
     }
 

--- a/hermes/bin/src/runtime_extensions/hermes/sqlite/core.rs
+++ b/hermes/bin/src/runtime_extensions/hermes/sqlite/core.rs
@@ -43,6 +43,13 @@ pub(super) fn open(
 
         (db_name, persistent_config)
     };
+
+    // Setting SQLITE_OPEN_NOMUTEX is enough, without setting env var, since
+    // by default SQLITE_THREADSAFE=1 is used, and doc says:
+    //
+    // If single-thread mode has not been selected at compile-time or start-time,
+    // then individual database connections can be created as either multi-thread or
+    // serialized.
     let flags = if readonly {
         SQLITE_OPEN_READONLY
     } else {
@@ -60,7 +67,7 @@ pub(super) fn open(
         return Err(Errno::FailedOpeningDatabase);
     }
 
-    let rc = unsafe { sqlite3_busy_timeout(db_ptr, 30000) };
+    let rc = unsafe { sqlite3_busy_timeout(db_ptr, 5000) };
     if rc != SQLITE_OK {
         return Err(Errno::Sqlite(rc));
     }

--- a/hermes/bin/tests/integration/components/sleep_component/src/lib.rs
+++ b/hermes/bin/tests/integration/components/sleep_component/src/lib.rs
@@ -22,7 +22,7 @@ use std::fs;
 use crate::utils::{busy_wait_s, make_payload, test_log};
 
 const REQUEST_COUNT: usize = 5;
-const WAIT_FOR_SECS: u64 = 1;
+const WAIT_FOR_SECS: u64 = 5;
 
 struct HttpRequestApp;
 

--- a/hermes/bin/tests/integration/components/sleep_component/src/lib.rs
+++ b/hermes/bin/tests/integration/components/sleep_component/src/lib.rs
@@ -2,7 +2,8 @@
 #![allow(
     clippy::missing_safety_doc,
     clippy::missing_docs_in_private_items,
-    clippy::expect_used
+    clippy::expect_used,
+    clippy::panic
 )]
 
 mod bindings {
@@ -16,16 +17,11 @@ mod bindings {
 mod stub;
 mod utils;
 
-use std::{
-    fs,
-    io::{Seek as _, SeekFrom, Write as _},
-};
+use std::fs;
 
 use crate::utils::{busy_wait_s, make_payload, test_log};
 
 const REQUEST_COUNT: usize = 5;
-const RESPONSES_FILE: &str = "responses.txt";
-const CONTENT: &[u8] = b"\xF0\x9F\xA6\x80\n";
 const WAIT_FOR_SECS: u64 = 1;
 
 struct HttpRequestApp;
@@ -43,10 +39,21 @@ impl bindings::exports::hermes::init::event::Guest for HttpRequestApp {
             .as_str()
             .expect("http_server is not a string");
 
-        let mut file = std::fs::File::create(RESPONSES_FILE).expect("failed to create file");
-        file.write_all(&[0; CONTENT.len()].repeat(REQUEST_COUNT))
-            .expect("failed to write to file");
-        file.flush().expect("failed to flush file");
+        let sqlite =
+            bindings::hermes::sqlite::api::open(false, false).expect("failed to connect to db");
+        sqlite
+            .execute(
+                r"
+                    CREATE TABLE IF NOT EXISTS counter (
+                        value INTEGER
+                    );
+                    ",
+            )
+            .expect("failed to create DB");
+        sqlite
+            .execute("INSERT INTO counter(value) VALUES(0);")
+            .expect("failed to insert counter");
+        sqlite.close().expect("failed to close connection");
 
         for i in 0..REQUEST_COUNT
             .try_into()
@@ -75,27 +82,54 @@ impl bindings::exports::hermes::http_request::event::Guest for HttpRequestApp {
         ));
         busy_wait_s(WAIT_FOR_SECS);
 
-        let mut file = std::fs::OpenOptions::new()
-            .write(true)
-            .open(RESPONSES_FILE)
-            .expect("failed to open file");
+        test_log(&format!("sqlite open request_id={request_id:?}"));
+        let sqlite = bindings::hermes::sqlite::api::open(false, false)
+            .inspect_err(|err| {
+                test_log(&format!(
+                    "open failed with request_id={request_id:?} and with: {err:?}"
+                ));
+            })
+            .expect("failed to connect to db");
+        test_log(&format!("sqlite prepare request_id={request_id:?}"));
+        let prep = sqlite
+            .prepare(
+                r"
+                    UPDATE counter
+                    SET value = value + 1
+                    RETURNING value;
+                ",
+            )
+            .inspect_err(|err| {
+                test_log(&format!(
+                    "prepare failed with request_id={request_id:?} and with: {err:?}"
+                ));
+            })
+            .expect("failed to prepare statement");
 
-        let request_id: usize = request_id
-            .unwrap_or_default()
-            .try_into()
-            .expect("failed to convert to usize");
-        let offset = request_id
-            .checked_mul(CONTENT.len())
-            .expect("offset overflow") as u64;
+        test_log(&format!("sqlite step request_id={request_id:?}"));
+        prep.step()
+            .inspect_err(|err| {
+                test_log(&format!(
+                    "step failed request_id={request_id:?} and with: {err:?}"
+                ));
+            })
+            .expect("failed to make step");
 
-        file.seek(SeekFrom::Start(offset)).expect("seek failed");
-        file.write_all(CONTENT).expect("failed to write content");
-        file.flush().expect("failed to flush");
+        test_log(&format!("sqlite column request_id={request_id:?}"));
+        let bindings::hermes::sqlite::api::Value::Int32(value) =
+            prep.column(0).expect("failed to get value")
+        else {
+            panic!("unexpected type!!!");
+        };
 
-        let data = std::fs::read(RESPONSES_FILE).expect("failed to read file");
-        let reference = CONTENT.repeat(5);
+        test_log(&format!("sqlite finalized request_id={request_id:?}"));
+        prep.finalize().expect("failed to finalize statement");
 
-        if data == reference {
+        test_log(&format!("sqlite close request_id={request_id:?}"));
+        sqlite.close().expect("failed to close connection");
+
+        let current_count: usize = value.try_into().expect("failed to convert i32 to usize");
+        if current_count == REQUEST_COUNT {
             test_log(&format!(
                 "All {REQUEST_COUNT} responses written correctly, calling done()",
             ));

--- a/hermes/bin/tests/integration/tests/serial/parallel_module_execution.rs
+++ b/hermes/bin/tests/integration/tests/serial/parallel_module_execution.rs
@@ -11,6 +11,7 @@ fn parallel_execution() {
     const COMPONENT: &str = "sleep_component";
     const COMPONENT_NAME: &str = "sleep_component";
     const MODULE_NAME: &str = "sleep_module";
+    const EXPECTED_EXECUTION_TIME_IN_SECONDS: u64 = 20;
 
     let temp_dir = TempDir::new().unwrap();
     utils::component::build(COMPONENT, &temp_dir, COMPONENT_NAME)
@@ -52,8 +53,8 @@ fn parallel_execution() {
         &format!("All {} responses written correctly, calling done()", 5)
     ));
 
-    // If events run in parallel, total time should be ~1 seconds, not ~5 seconds
-    // Allow some margin for startup/shutdown time
+    // If events run in parallel, total time should be ~5 seconds, not ~25 seconds
+    // Allow some margin for startup/shutdown time and database contention
     //
     // Note: if there is not enough threads, then we would have some kind of sequential
     // execution, so this assert would not pass
@@ -65,9 +66,10 @@ fn parallel_execution() {
         > 6
     {
         assert!(
-            execution_time.as_secs() < 3,
-            "Execution took {} seconds, expected less than 3 seconds for parallel execution",
-            execution_time.as_secs()
+            execution_time.as_secs() < EXPECTED_EXECUTION_TIME_IN_SECONDS,
+            "Execution took {} seconds, expected less than {} seconds for parallel execution",
+            execution_time.as_secs(),
+            EXPECTED_EXECUTION_TIME_IN_SECONDS
         );
     }
 


### PR DESCRIPTION
# Description

Updates current codebase, so that parrallel writings to database does not fail.

## Related Issue(s)

Fixes #517

## Description of Changes

- Add `SQLITE_OPEN_NOMUTEX` flag to `open`, so sqlite works in multi-thread mode.
- Add `busy_handler` that always retries SQLITE_BUSY.
- Add liveness test for parallel execution.
- Add `enable_wal_mode` function to enable WAL mode in the future, after this [issue](https://github.com/input-output-hk/hermes/issues/521) would be resolved.
- Updated `parallel_execution` test to use database instead of file.

## Related Pull Requests

Updates test in [PR](https://github.com/input-output-hk/hermes/pull/488), so it uses database instead of hack with file.

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
