### PR TITLE
fix: libc header not found when build wasm-wasip2 for module that use catlib `rbac-registration` (ARM architect)

### DIFF
--- a/hermes/apps/athena/modules/Earthfile
+++ b/hermes/apps/athena/modules/Earthfile
@@ -139,3 +139,14 @@ save-local-hermes:
     # Save the binary to local filesystem for development use
     # This makes it available at ./hermes in the calling directory
     SAVE ARTIFACT hermes AS LOCAL ./hermes
+
+# Build wasm32-wasip2 for each modules
+modules-build-wasm32-wasip2:
+    BUILD ./rbac-registration+build-rbac-registration
+    BUILD ./rbac-registration-indexer+build-rbac-registration-indexer
+    BUILD ./http-proxy+build-http-proxy
+
+# Run build modules wasm32-wasip2 for the specify architect
+# Comment this out if it take long time for CI to build.
+build-all-host-modules-build-wasm32-wasip2:
+    BUILD --platform=linux/amd64 --platform=linux/arm64 +modules-build-wasm32-wasip2

--- a/wasm/wasi/Earthfile
+++ b/wasm/wasi/Earthfile
@@ -94,6 +94,9 @@ BUILD_RUST_COMPONENT:
     COPY --keep-ts --dir src .
     COPY Cargo.toml .
 
+    # Fix missing header error when compiling zstd while building rbac-registration
+    ENV CFLAGS_wasm32_wasip2="--sysroot=/usr/aarch64-linux-gnu"
+
     DO rust-ci+CARGO \
         --args "build --target wasm32-wasip2 --release" \
         --output="wasm32-wasip2/release/$out"


### PR DESCRIPTION
# Description

Fix libc header not found when build wasm-wasip2 for module that use catlib `rbac-registration` (ARM architect)

## Related Issue(s)

Closes #555

## Please confirm the following checks

* [ ] My code follows the style guidelines of this project
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
