### PR TITLE
feat(athena): shared log macros

### DIFF
--- a/hermes/apps/athena/Cargo.lock
+++ b/hermes/apps/athena/Cargo.lock
@@ -167,6 +167,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
+name = "bech32"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
+
+[[package]]
 name = "bimap"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -684,6 +690,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "erased-serde"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "259d404d09818dec19332e31d94558aeb442fea04c817006456c24b5460bbd4b"
+dependencies = [
+ "serde",
+ "serde_core",
+ "typeid",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1092,6 +1109,10 @@ name = "log"
 version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+dependencies = [
+ "serde",
+ "value-bag",
+]
 
 [[package]]
 name = "memchr"
@@ -1384,7 +1405,7 @@ version = "1.0.0-alpha.2"
 source = "git+https://github.com/input-output-hk/catalyst-pallas.git?branch=feat%2Fpallas-network-types#9cfb41cb4f15f913fc17388cec4ccd87c3551ff0"
 dependencies = [
  "base58",
- "bech32",
+ "bech32 0.9.1",
  "crc",
  "cryptoxide",
  "hex",
@@ -1685,11 +1706,21 @@ name = "rbac-registration"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bech32 0.11.0",
+ "c509-certificate",
  "cardano-blockchain-types",
  "catalyst-types 0.0.7",
+ "chrono",
+ "ed25519-dalek",
+ "hex",
+ "minicbor 0.25.1",
  "rbac-registration 0.0.10",
+ "regex",
+ "serde",
  "serde_json",
  "shared",
+ "uuid",
+ "x509-cert",
 ]
 
 [[package]]
@@ -1889,6 +1920,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_fmt"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d4ddca14104cd60529e8c7f7ba71a2c8acd8f7f5cfcdc2faf97eeb7c3010a4"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1951,10 +1991,11 @@ dependencies = [
  "anyhow",
  "cardano-blockchain-types",
  "catalyst-types 0.0.7",
+ "log",
  "serde_json",
  "strum 0.27.2",
  "strum_macros 0.27.2",
- "wit-bindgen 0.43.0",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -2097,6 +2138,84 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "sval"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d94c4464e595f0284970fd9c7e9013804d035d4a61ab74b113242c874c05814d"
+
+[[package]]
+name = "sval_buffer"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0f46e34b20a39e6a2bf02b926983149b3af6609fd1ee8a6e63f6f340f3e2164"
+dependencies = [
+ "sval",
+ "sval_ref",
+]
+
+[[package]]
+name = "sval_dynamic"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03d0970e53c92ab5381d3b2db1828da8af945954d4234225f6dd9c3afbcef3f5"
+dependencies = [
+ "sval",
+]
+
+[[package]]
+name = "sval_fmt"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43e5e6e1613e1e7fc2e1a9fdd709622e54c122ceb067a60d170d75efd491a839"
+dependencies = [
+ "itoa",
+ "ryu",
+ "sval",
+]
+
+[[package]]
+name = "sval_json"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aec382f7bfa6e367b23c9611f129b94eb7daaf3d8fae45a8d0a0211eb4d4c8e6"
+dependencies = [
+ "itoa",
+ "ryu",
+ "sval",
+]
+
+[[package]]
+name = "sval_nested"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3049d0f99ce6297f8f7d9953b35a0103b7584d8f638de40e64edb7105fa578ae"
+dependencies = [
+ "sval",
+ "sval_buffer",
+ "sval_ref",
+]
+
+[[package]]
+name = "sval_ref"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f88913e77506085c0a8bf6912bb6558591a960faf5317df6c1d9b227224ca6e1"
+dependencies = [
+ "sval",
+]
+
+[[package]]
+name = "sval_serde"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f579fd7254f4be6cd7b450034f856b78523404655848789c451bacc6aa8b387d"
+dependencies = [
+ "serde_core",
+ "sval",
+ "sval_nested",
+]
 
 [[package]]
 name = "syn"
@@ -2279,6 +2398,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
 name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2309,6 +2434,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "value-bag"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "943ce29a8a743eb10d6082545d861b24f9d1b160b7d741e0f2cdf726bec909c5"
+dependencies = [
+ "value-bag-serde1",
+ "value-bag-sval2",
+]
+
+[[package]]
+name = "value-bag-serde1"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35540706617d373b118d550d41f5dfe0b78a0c195dc13c6815e92e2638432306"
+dependencies = [
+ "erased-serde",
+ "serde",
+ "serde_fmt",
+]
+
+[[package]]
+name = "value-bag-sval2"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe7e140a2658cc16f7ee7a86e413e803fc8f9b5127adc8755c19f9fefa63a52"
+dependencies = [
+ "sval",
+ "sval_buffer",
+ "sval_dynamic",
+ "sval_fmt",
+ "sval_json",
+ "sval_ref",
+ "sval_serde",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2335,7 +2496,7 @@ version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen 0.46.0",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -2399,9 +2560,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.235.0"
+version = "0.239.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3bc393c395cb621367ff02d854179882b9a351b4e0c93d1397e6090b53a5c2a"
+checksum = "5be00faa2b4950c76fe618c409d2c3ea5a3c9422013e079482d78544bb2d184c"
 dependencies = [
  "leb128fmt",
  "wasmparser",
@@ -2409,9 +2570,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-metadata"
-version = "0.235.0"
+version = "0.239.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b055604ba04189d54b8c0ab2c2fc98848f208e103882d5c0b984f045d5ea4d20"
+checksum = "20b3ec880a9ac69ccd92fbdbcf46ee833071cf09f82bb005b2327c7ae6025ae2"
 dependencies = [
  "anyhow",
  "indexmap 2.11.4",
@@ -2421,9 +2582,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.235.0"
+version = "0.239.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "161296c618fa2d63f6ed5fffd1112937e803cb9ec71b32b01a76321555660917"
+checksum = "8c9d90bb93e764f6beabf1d02028c70a2156a6583e63ac4218dd07ef733368b0"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
@@ -2649,25 +2810,21 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.43.0"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a18712ff1ec5bd09da500fe1e91dec11256b310da0ff33f8b4ec92b927cf0c6"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 dependencies = [
- "wit-bindgen-rt",
+ "bitflags",
+ "futures",
+ "once_cell",
  "wit-bindgen-rust-macro",
 ]
 
 [[package]]
-name = "wit-bindgen"
+name = "wit-bindgen-core"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.43.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c53468e077362201de11999c85c07c36e12048a990a3e0d69da2bd61da355d0"
+checksum = "cabd629f94da277abc739c71353397046401518efb2c707669f805205f0b9890"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -2675,21 +2832,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.43.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fd734226eac1fd7c450956964e3a9094c9cee65e9dafdf126feef8c0096db65"
-dependencies = [
- "bitflags",
- "futures",
- "once_cell",
-]
-
-[[package]]
 name = "wit-bindgen-rust"
-version = "0.43.0"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531ebfcec48e56473805285febdb450e270fa75b2dacb92816861d0473b4c15f"
+checksum = "9a4232e841089fa5f3c4fc732a92e1c74e1a3958db3b12f1de5934da2027f1f4"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -2703,9 +2849,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust-macro"
-version = "0.43.0"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7852bf8a9d1ea80884d26b864ddebd7b0c7636697c6ca10f4c6c93945e023966"
+checksum = "1e0d4698c2913d8d9c2b220d116409c3f51a7aa8d7765151b886918367179ee9"
 dependencies = [
  "anyhow",
  "prettyplease",
@@ -2718,9 +2864,9 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.235.0"
+version = "0.239.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a57a11109cc553396f89f3a38a158a97d0b1adaec113bd73e0f64d30fb601f"
+checksum = "88a866b19dba2c94d706ec58c92a4c62ab63e482b4c935d2a085ac94caecb136"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -2737,9 +2883,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.235.0"
+version = "0.239.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a1f95a87d03a33e259af286b857a95911eb46236a0f726cbaec1227b3dfc67a"
+checksum = "55c92c939d667b7bf0c6bf2d1f67196529758f99a2a45a3355cc56964fd5315d"
 dependencies = [
  "anyhow",
  "id-arena",

--- a/hermes/apps/athena/modules/http-proxy/lib/version.json
+++ b/hermes/apps/athena/modules/http-proxy/lib/version.json
@@ -1,1 +1,1 @@
-{"app_name":"catalyst_voices","version":"0.1.0","build_number":"1759917037","package_name":"catalyst_voices"}
+{"app_name":"catalyst_voices","version":"0.1.0","build_number":"1760367394","package_name":"catalyst_voices"}

--- a/hermes/apps/athena/modules/http-proxy/src/lib.rs
+++ b/hermes/apps/athena/modules/http-proxy/src/lib.rs
@@ -24,6 +24,7 @@ use std::sync::OnceLock;
 
 use hermes::http_gateway::api::{Bstr, Headers, HttpGatewayResponse, HttpResponse};
 use regex::RegexSet;
+use shared::utils::log::{self, debug, info, warn};
 
 shared::bindings_generate!({
     world: "hermes:app/hermes",
@@ -37,14 +38,11 @@ shared::bindings_generate!({
             import hermes:http-gateway/api;
 
             export hermes:http-gateway/event;
-            
         }
     ",
     share: ["hermes:logging"],
 });
 export!(HttpProxyComponent);
-
-use shared::bindings::hermes::logging::api::{log, Level};
 
 /// What to do when a route pattern matches
 #[derive(Debug, Clone, Copy)]
@@ -104,7 +102,7 @@ fn init_route_matcher() -> &'static (RegexSet, Vec<RouteAction>) {
 
         // Compile all patterns together for performance
         let regex_set = RegexSet::new(&patterns).unwrap_or_else(|e| {
-            log_warn(&format!("Failed to compile patterns: {}", e));
+            warn!(error:err = e; "Failed to compile patterns");
             RegexSet::empty()
         });
 
@@ -131,14 +129,14 @@ fn is_static_content(path: &str) -> bool {
 /// Creates an external route redirect response
 /// Currently redirects to Cat Voices - will become configurable backend selection
 fn create_external_redirect(path: &str) -> HttpGatewayResponse {
-    log_debug(&format!("Routing externally to Cat Voices: {}", path));
+    debug!(path; "Routing externally to Cat Voices");
     HttpGatewayResponse::InternalRedirect(format!("{}{}", EXTERNAL_HOST, path))
 }
 
 /// Creates a static content response (native handling)
 /// TODO: Integrate with configurable static content serving middleware
 fn create_static_response(path: &str) -> HttpGatewayResponse {
-    log_debug(&format!("Serving static content natively: {}", path));
+    debug!(path; "Serving static content natively");
     HttpGatewayResponse::Http(HttpResponse {
         code: 200,
         headers: vec![("content-type".to_string(), vec!["text/plain".to_string()])],
@@ -152,57 +150,16 @@ fn create_not_found_response(
     method: &str,
     path: &str,
 ) -> HttpGatewayResponse {
-    log_warn(&format!(
-        "Route not found (no native implementation or external routing configured): {} {}",
-        method, path
-    ));
+    warn!(
+        method,
+        path;
+        "Route not found (no native implementation or external routing configured)",
+    );
     HttpGatewayResponse::Http(HttpResponse {
         code: 404,
         headers: vec![("content-type".to_string(), vec!["text/html".to_string()])],
         body: Bstr::from("<html><body><h1>404 - Page Not Found</h1></body></html>"),
     })
-}
-
-/// Logs an info message
-fn log_info(message: &str) {
-    log(
-        Level::Info,
-        Some("http-proxy"),
-        None,
-        None,
-        None,
-        None,
-        message,
-        None,
-    );
-}
-
-/// Logs a debug message
-fn log_debug(message: &str) {
-    log(
-        Level::Debug,
-        Some("http-proxy"),
-        None,
-        None,
-        None,
-        None,
-        message,
-        None,
-    );
-}
-
-/// Logs a warning message
-fn log_warn(message: &str) {
-    log(
-        Level::Warn,
-        Some("http-proxy"),
-        None,
-        None,
-        None,
-        None,
-        message,
-        None,
-    );
 }
 
 /// Formats the response type for logging
@@ -227,7 +184,9 @@ impl exports::hermes::http_gateway::event::Guest for HttpProxyComponent {
         path: String,
         method: String,
     ) -> Option<HttpGatewayResponse> {
-        log_info(&format!("Processing HTTP request: {} {}", method, path));
+        log::init(log::LevelFilter::Trace);
+
+        info!("Processing HTTP request: {} {}", method, path);
 
         let response = if should_route_externally(&path) {
             create_external_redirect(&path)
@@ -237,12 +196,12 @@ impl exports::hermes::http_gateway::event::Guest for HttpProxyComponent {
             create_not_found_response(&method, &path)
         };
 
-        log_info(&format!(
-            "Request completed: {} {} -> {}",
+        info!(
             method,
             path,
-            format_response_type(&response)
-        ));
+            response = format_response_type(&response);
+            "Request completed",
+        );
 
         Some(response)
     }

--- a/hermes/apps/athena/shared/Cargo.toml
+++ b/hermes/apps/athena/shared/Cargo.toml
@@ -10,6 +10,7 @@ anyhow = "1.0.98"
 serde_json = "1.0.142"
 strum = "0.27.2"
 strum_macros = "0.27.2"
+log = { version = "0.4.28", features = ["kv_serde"] }
 
 cardano-blockchain-types = { version = "0.0.6", git = "https://github.com/input-output-hk/catalyst-libs", tag = "cardano-blockchain-types/v0.0.6", optional = true }
 catalyst-types = { version = "0.0.7", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "catalyst-types/v0.0.7" }

--- a/hermes/apps/athena/shared/src/utils/log.rs
+++ b/hermes/apps/athena/shared/src/utils/log.rs
@@ -1,44 +1,149 @@
 //! Logging utilities.
 
-// TODO - This should be removed once <https://github.com/input-output-hk/hermes/issues/505> is implemented.
-use crate::bindings::hermes::logging::api::{log, Level};
+use std::sync::Once;
 
-/// Error logging.
-pub fn log_error(
-    file: &str,
-    function: &str,
-    context: &str,
-    msg: &str,
-    data: Option<&str>,
-) {
-    log(
-        Level::Error,
-        Some(file),
-        Some(function),
-        None,
-        None,
-        Some(context),
-        &format!("🚨 {msg}"),
-        data,
-    );
+use log::Log;
+pub use log::{debug, error, info, log_enabled, trace, warn, LevelFilter};
+
+/// Compatibility between [`hermes::logging`] and [`log`].
+mod compat {
+    use crate::bindings::hermes;
+
+    /// Converts from [`log::Level`] to the compatible level from bindings.
+    fn convert_level(compat: log::Level) -> hermes::logging::api::Level {
+        match compat {
+            log::Level::Error => hermes::logging::api::Level::Error,
+            log::Level::Warn => hermes::logging::api::Level::Warn,
+            log::Level::Info => hermes::logging::api::Level::Info,
+            log::Level::Debug => hermes::logging::api::Level::Debug,
+            log::Level::Trace => hermes::logging::api::Level::Trace,
+        }
+    }
+
+    /// Serializes logged key-value pairs to json.
+    #[derive(Default)]
+    struct DataVisitor(serde_json::Map<String, serde_json::Value>);
+
+    impl<'kvs> log::kv::VisitSource<'kvs> for DataVisitor {
+        fn visit_pair(
+            &mut self,
+            key: log::kv::Key<'kvs>,
+            value: log::kv::Value<'kvs>,
+        ) -> Result<(), log::kv::Error> {
+            let value = serde_json::to_value(&value)
+                .unwrap_or_else(|_| serde_json::Value::String(value.to_string()));
+            self.0.insert(key.as_str().to_owned(), value);
+            Ok(())
+        }
+    }
+
+    /// Hermes compatible log record.
+    pub struct Record<'a> {
+        level: hermes::logging::api::Level,
+        file: Option<&'a str>,
+        line: Option<u32>,
+        function: Option<String>,
+        ctx: Option<&'a str>,
+        msg: String,
+        data: Option<String>,
+    }
+
+    impl<'a> From<&'a log::Record<'a>> for Record<'a> {
+        fn from(value: &'a log::Record<'a>) -> Self {
+            Self {
+                level: convert_level(value.level()),
+                file: value.file(),
+                line: value.line(),
+                // Function cannot be easily retrieved, so it is anonymized as "xxx".
+                function: value
+                    .module_path()
+                    .map(|module_path| format!("{module_path}::xxx")),
+                // Target maps to context.
+                ctx: Some(value.target()),
+                // Arguments are formatted same way `print!` formats them.
+                msg: format!("{}", value.args()),
+                // Structured data becomes json.
+                data: {
+                    let mut visitor = DataVisitor::default();
+                    // Data serialization should not return errors by implementation.
+                    let _ = value.key_values().visit(&mut visitor);
+                    (!visitor.0.is_empty())
+                        .then(|| serde_json::to_string(&visitor.0).ok())
+                        .flatten()
+                },
+            }
+        }
+    }
+
+    impl Record<'_> {
+        /// Log the record through Hermes logging api.
+        pub fn log(self) {
+            hermes::logging::api::log(
+                self.level,
+                self.file,
+                self.function.as_deref(),
+                self.line,
+                None,
+                self.ctx,
+                &self.msg,
+                self.data.as_deref(),
+            );
+        }
+    }
 }
 
-/// Info logging.
-pub fn log_info(
-    file: &str,
-    function: &str,
+/// Forwards [`log`] macros input to Hermes WASM bindings.
+struct LogImpl;
+
+impl Log for LogImpl {
+    fn enabled(
+        &self,
+        metadata: &log::Metadata,
+    ) -> bool {
+        metadata.level() <= log::max_level()
+    }
+
+    fn log(
+        &self,
+        record: &log::Record,
+    ) {
+        if self.enabled(record.metadata()) {
+            compat::Record::from(record).log();
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+/// Initialize [`log`] macros. This must be called at least once to enable logging.
+pub fn init(filter: LevelFilter) {
+    const ONCE: Once = Once::new();
+    ONCE.call_once(move || {
+        let _ = log::set_logger(&LogImpl);
+        log::set_max_level(filter);
+    });
+}
+
+// TODO: replace `log_error` calls with `log::info!` macro invocations.
+/// Error logging.
+pub fn log_error(
+    _: &str,
+    _: &str,
     context: &str,
     msg: &str,
     data: Option<&str>,
 ) {
-    log(
-        Level::Info,
-        Some(file),
-        Some(function),
-        None,
-        None,
-        Some(context),
-        msg,
-        data,
-    );
+    log::error!(target: context, data; "{msg}");
+}
+
+// TODO: replace `log_info` calls with `log::info!` macro invocations.
+/// Info logging.
+pub fn log_info(
+    _: &str,
+    _: &str,
+    context: &str,
+    msg: &str,
+    data: Option<&str>,
+) {
+    log::info!(target: context, data; "{msg}");
 }


### PR DESCRIPTION
# Description

Thanks for contributing to the project!
Please fill out this template to help us review your changes.

## Related Issue(s)

List the issue numbers related to this pull request.

Closes #505

## Description of Changes

A small PR that integrates [log](https://docs.rs/log/latest/log) crate with Hermes logging RTE on Athena side. In other words, regular `error!`, `warn!`, `info!`, `debug!` and `trace!` macros work from within Athena as expected.

[log](https://docs.rs/log/latest/log) was chosen over [tracing](https://docs.rs/tracing/latest/tracing), because the former is easier to integrate: Hermes doesn't have a concept  of `span!` yet, which is the backbone of the latter.

I've also replaced logging functions in `http-proxy` with these.

## Breaking Changes

No breaking changes.

## Screenshots

If applicable, add screenshots to help explain your changes.

## Related Pull Requests

If applicable, list any related pull requests.

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
