### PR TITLE
chore(catalyst-ci): Update catalyst-ci to v3.6.0

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -1,7 +1,7 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/mdlint:v3.5.28 AS mdlint-ci
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/cspell:v3.5.28 AS cspell-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/mdlint:v3.6.0 AS mdlint-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/cspell:v3.6.0 AS cspell-ci
 
 
 # cspell: words livedocs sitedocs

--- a/docs/Earthfile
+++ b/docs/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/docs:v3.5.28 AS docs-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/docs:v3.6.0 AS docs-ci
 
 IMPORT .. AS repo
 IMPORT ../hermes AS hermes

--- a/hermes/Earthfile
+++ b/hermes/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.5.28 AS rust-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.6.0 AS rust-ci
 
 # Use when debugging cat-ci locally.
 # IMPORT ../../catalyst-ci/earthly/rust AS rust-ci

--- a/hermes/apps/athena/Earthfile
+++ b/hermes/apps/athena/Earthfile
@@ -1,7 +1,7 @@
 VERSION 0.8
 
 IMPORT ../../../wasm AS wasm
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.5.28 AS rust-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.6.0 AS rust-ci
 
 # Make an artifact which consists of the common code shared by Athena modules.
 workspace-src:

--- a/utilities/docs-preview/Earthfile
+++ b/utilities/docs-preview/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/docs:v3.5.28 AS docs-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/docs:v3.6.0 AS docs-ci
 
 # update-docs-dev-script: get the latest docs dev script from CI.
 update-docs-dev-script:

--- a/wasm/integration-test/golang/Earthfile
+++ b/wasm/integration-test/golang/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/go:v3.5.28 AS go-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/go:v3.6.0 AS go-ci
 
 IMPORT ../.. AS wasm
 

--- a/wasm/wasi/Earthfile
+++ b/wasm/wasi/Earthfile
@@ -1,8 +1,8 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.5.28 AS rust-ci
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/go:v3.5.28 AS go-ci
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/wasm/c:v3.5.28 AS wasm-c-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.6.0 AS rust-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/go:v3.6.0 AS go-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/wasm/c:v3.6.0 AS wasm-c-ci
 
 # Use when debugging cat-ci locally.
 # IMPORT ../../catalyst-ci/earthly/rust AS rust-ci


### PR DESCRIPTION
Update catalyst-ci to v3.6.0. Release: https://github.com/input-output-hk/catalyst-ci/releases/tag/v3.6.0