### PR TITLE
chore(hermes): Rename `kernel` back to `core`

### DIFF
--- a/hermes/bin/src/runtime_extensions/hermes/sqlite/connection/core.rs
+++ b/hermes/bin/src/runtime_extensions/hermes/sqlite/connection/core.rs
@@ -12,7 +12,7 @@ use stringzilla::stringzilla::StringZillableBinary;
 
 use crate::runtime_extensions::{
     bindings::hermes::sqlite::api::{Errno, ErrorInfo},
-    hermes::sqlite::kernel,
+    hermes::sqlite::core,
 };
 
 /// Checks if the provided SQL string contains a `PRAGMA` statement.
@@ -33,9 +33,9 @@ pub(crate) fn close(db_ptr: *mut sqlite3) -> Result<(), Errno> {
 }
 
 /// Same as [`close`] but additionally removes all sqlite files with
-/// [`kernel::DbPaths::remove_all`].
+/// [`core::DbPaths::remove_all`].
 pub(crate) fn close_and_remove_all(db_ptr: *mut sqlite3) -> anyhow::Result<()> {
-    let paths = kernel::DbPaths::main(db_ptr)?;
+    let paths = core::DbPaths::main(db_ptr)?;
     close(db_ptr)?;
     paths.remove_all()?;
     Ok(())
@@ -130,7 +130,7 @@ mod tests {
         runtime_extensions::{
             bindings::hermes::sqlite::api::Value,
             hermes::sqlite::{
-                kernel::{self, open},
+                core::{self, open},
                 statement::core::{column, finalize, step},
             },
         },
@@ -272,7 +272,7 @@ mod tests {
     fn test_close_and_remove_all_simple() {
         let app_name = TMP_DIR.to_owned();
         let db_ptr = init_fs(app_name).unwrap();
-        let paths = kernel::DbPaths::main(db_ptr).unwrap();
+        let paths = core::DbPaths::main(db_ptr).unwrap();
 
         let database_created = std::fs::exists(&paths.database).unwrap();
         let _journal_created = std::fs::exists(&paths.journal).unwrap();

--- a/hermes/bin/src/runtime_extensions/hermes/sqlite/core.rs
+++ b/hermes/bin/src/runtime_extensions/hermes/sqlite/core.rs
@@ -207,8 +207,8 @@ pub(super) fn open_with_persistent_memory(
     memory: bool,
     app_name: ApplicationName,
 ) -> Result<*mut sqlite3, Errno> {
-    // Internally `kernel::open` derives db path from `ApplicationName`, treating it as no
-    // more than a string. So, it is okay to substitute it at `kernel::open` level to
+    // Internally `core::open` derives db path from `ApplicationName`, treating it as no
+    // more than a string. So, it is okay to substitute it at `core::open` level to
     // create another file. Once the pointer is obtained, however, it must be bound to the
     // resource under the original `app_name`.
     let db_name = if memory {

--- a/hermes/bin/src/runtime_extensions/hermes/sqlite/host.rs
+++ b/hermes/bin/src/runtime_extensions/hermes/sqlite/host.rs
@@ -6,7 +6,7 @@ use crate::{
         bindings::hermes::sqlite::api::{Errno, Host, Sqlite},
         hermes::sqlite::{
             connection::core::close,
-            kernel,
+            core,
             state::{connection::DbHandle, resource_manager},
         },
     },
@@ -38,7 +38,7 @@ impl Host for HermesRuntimeContext {
             return Ok(Ok(resource));
         }
 
-        match kernel::open_with_persistent_memory(readonly, memory, self.app_name().clone()) {
+        match core::open_with_persistent_memory(readonly, memory, self.app_name().clone()) {
             Ok(db_ptr) => {
                 match resource_manager::create_connection_resource(
                     self.app_name(),

--- a/hermes/bin/src/runtime_extensions/hermes/sqlite/mod.rs
+++ b/hermes/bin/src/runtime_extensions/hermes/sqlite/mod.rs
@@ -8,7 +8,7 @@ use crate::{
     runtime_extensions::{
         bindings::hermes::sqlite::api::Errno,
         hermes::sqlite::{
-            connection::core::close_and_remove_all, kernel::open_with_persistent_memory,
+            connection::core::close_and_remove_all, core::open_with_persistent_memory,
             state::resource_manager::init_app_state,
         },
         init::{
@@ -24,8 +24,8 @@ use crate::{
 };
 
 mod connection;
+mod core;
 mod host;
-mod kernel;
 mod state;
 mod statement;
 

--- a/hermes/bin/src/runtime_extensions/hermes/sqlite/statement/core.rs
+++ b/hermes/bin/src/runtime_extensions/hermes/sqlite/statement/core.rs
@@ -148,7 +148,7 @@ mod tests {
         app::ApplicationName,
         runtime_extensions::hermes::sqlite::{
             connection::core::{self, close, execute, prepare},
-            kernel::open,
+            core::open,
         },
     };
 


### PR DESCRIPTION
# Description

Rename the `kernel` module back to `core`.

## Related Issue(s)

Closes: https://github.com/input-output-hk/hermes/issues/668

## Please confirm the following checks

* [X] My code follows the style guidelines of this project
* [X] I have performed a self-review of my code
* [X] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [X] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [X] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
