### PR TITLE
feat(hermes): set max database size

### DIFF
--- a/hermes/bin/src/runtime_extensions/app_config.rs
+++ b/hermes/bin/src/runtime_extensions/app_config.rs
@@ -4,8 +4,8 @@ use std::path::PathBuf;
 
 use crate::app::ApplicationName;
 
-/// Maximum configurable DB Size.
-const MAX_CONFIG_DB_SIZE: u32 = 1_048_576;
+/// Maximum configurable DB Size (~ 4.3 GB).
+const MAX_CONFIG_DB_SIZE: u32 = u32::MAX;
 
 /// Configuration struct for `SQLite` database.
 ///


### PR DESCRIPTION
# Description

This PR sets Application db size to maximum allowed value (in u32), so it fixes `SQLite(13)`.

## Description of Changes

- `MAX_CONFIG_DB_SIZE` is set to `u32::MAX`

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
