### PR TITLE
chore(deps): bump wasmprinter from 0.240.0 to 0.242.0 in /hermes

### DIFF
--- a/hermes/Cargo.lock
+++ b/hermes/Cargo.lock
@@ -3162,7 +3162,7 @@ dependencies = [
  "url",
  "usvg",
  "uuid",
- "wasmprinter 0.242.0",
+ "wasmprinter 0.243.0",
  "wasmtime",
  "wasmtime-wasi",
  "wat",
@@ -9225,6 +9225,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmparser"
+version = "0.243.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6d8db401b0528ec316dfbe579e6ab4152d61739cfe076706d2009127970159d"
+dependencies = [
+ "bitflags 2.10.0",
+ "indexmap 2.12.1",
+ "semver",
+]
+
+[[package]]
 name = "wasmprinter"
 version = "0.240.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9237,13 +9248,13 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.242.0"
+version = "0.243.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936a79bf33649f3aa0cd7cdf495e62ac0c718b3630ab53946df6dc2eff73a0d6"
+checksum = "eb2b6035559e146114c29a909a3232928ee488d6507a1504d8934e8607b36d7b"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.242.0",
+ "wasmparser 0.243.0",
 ]
 
 [[package]]

--- a/hermes/bin/Cargo.toml
+++ b/hermes/bin/Cargo.toml
@@ -100,7 +100,7 @@ paste = { package = "pastey", version = "0.1.1" }
 traitreg = "0.4.0"
 orx-concurrent-vec = "3.10.0"
 keyed-lock = "0.2.3"
-wasmprinter = "0.242.0"
+wasmprinter = "0.243.0"
 wat = "1.239.0"
 multihash = { version = "0.19.3", features = ["serde-codec"] }
 


### PR DESCRIPTION
# Description

Bumps [wasmprinter](https://github.com/bytecodealliance/wasm-tools) from 0.240.0 to 0.242.0.
- [Release notes](https://github.com/bytecodealliance/wasm-tools/releases)
- [Commits](https://github.com/bytecodealliance/wasm-tools/commits)

---
updated-dependencies:
- dependency-name: wasmprinter dependency-version: 0.242.0 dependency-type: direct:production update-type: version-update:semver-minor ...
