### PR TITLE
chore(hermes): Rework `async` in `HermesIpfs`

### DIFF
--- a/.config/dictionaries/project.dic
+++ b/.config/dictionaries/project.dic
@@ -219,6 +219,7 @@ txos
 unfinalized
 unlinkat
 unsub
+unsubscription
 usermod
 usvg
 utimensat

--- a/hermes/bin/Cargo.toml
+++ b/hermes/bin/Cargo.toml
@@ -31,7 +31,7 @@ path = "tests/integration/tests/mod.rs"
 
 [dependencies]
 # Catalyst Internal Crates
-hermes-ipfs = { version = "0.0.12", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "hermes-ipfs/v0.0.12", features = ["doc-sync"] }
+hermes-ipfs = { version = "0.0.13", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "hermes-ipfs/v0.0.13", features = ["doc-sync"] }
 cardano-blockchain-types = { version = "0.0.9", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "cardano-blockchain-types/v0.0.9" }
 cardano-chain-follower = { version = "0.0.19", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "cardano-chain-follower/v0.0.19" }
 catalyst-types = { version = "0.0.12", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "catalyst-types/v0.0.12" }

--- a/hermes/bin/src/ipfs/blocking.rs
+++ b/hermes/bin/src/ipfs/blocking.rs
@@ -1,3 +1,8 @@
+//! Hermes IPFS service.
+//!
+//! This module contains the blocking alternatives to IPFS function as opposed to async
+//! enabled functions.
+
 use std::{
     convert::Infallible,
     sync::{Arc, Mutex},

--- a/hermes/bin/src/ipfs/blocking.rs
+++ b/hermes/bin/src/ipfs/blocking.rs
@@ -110,7 +110,7 @@ pub(crate) fn hermes_ipfs_get_peer_identity(
     Ok(identity)
 }
 
-/// Subscribe to a topic from in the non-async context.
+/// Subscribe to a topic in the non-async context.
 pub(crate) fn hermes_ipfs_subscribe(
     kind: SubscriptionKind,
     app_name: &ApplicationName,

--- a/hermes/bin/src/ipfs/blocking.rs
+++ b/hermes/bin/src/ipfs/blocking.rs
@@ -10,10 +10,11 @@ use super::task::IpfsCommand;
 pub(crate) use super::task::SubscriptionKind;
 use crate::{
     app::ApplicationName,
-    ipfs::HermesIpfsNode,
+    ipfs::{HERMES_IPFS, HermesIpfsNode},
     runtime_extensions::{
         bindings::hermes::ipfs::api::{Errno, MessageData, PeerId, PubsubTopic},
         hermes,
+        hermes::doc_sync,
     },
     wasm::module::ModuleId,
 };
@@ -95,4 +96,101 @@ where N: hermes_ipfs::rust_ipfs::NetworkBehaviour<ToSwarm = Infallible> + Send +
             .blocking_recv()
             .map_err(|_| Errno::PubsubUnsubscribeError)?
     }
+}
+
+/// Returns the peer id of the node in the non-async context.
+pub(crate) fn hermes_ipfs_get_peer_identity(
+    peer: Option<PeerId>
+) -> Result<Option<hermes_ipfs::PeerInfo>, Errno> {
+    let ipfs = HERMES_IPFS.get().ok_or(Errno::ServiceUnavailable)?;
+
+    let identity = ipfs.get_peer_identity_blocking(peer)?;
+    tracing::debug!("Got peer identity");
+
+    Ok(identity)
+}
+
+/// Subscribe to a topic from in the non-async context.
+pub(crate) fn hermes_ipfs_subscribe(
+    kind: SubscriptionKind,
+    app_name: &ApplicationName,
+    tree: Option<Arc<Mutex<Tree<doc_sync::Cid>>>>,
+    topic: &PubsubTopic,
+    module_ids: Option<&Vec<ModuleId>>,
+) -> Result<bool, Errno> {
+    let ipfs = HERMES_IPFS.get().ok_or(Errno::ServiceUnavailable)?;
+    tracing::debug!(app_name = %app_name, pubsub_topic = %topic, "subscribing to PubSub topic");
+    if ipfs.apps.topic_subscriptions_contains(kind, topic) {
+        tracing::debug!(app_name = %app_name, pubsub_topic = %topic, "topic subscription stream already exists");
+    } else {
+        let handle = ipfs.pubsub_subscribe_blocking(kind, topic, tree, app_name, module_ids)?;
+        ipfs.apps.added_topic_stream(kind, topic.clone(), handle);
+        tracing::debug!(app_name = %app_name, pubsub_topic = %topic, "added subscription topic stream");
+    }
+    ipfs.apps
+        .added_app_topic_subscription(kind, app_name.clone(), topic.clone());
+    Ok(true)
+}
+
+/// Unsubscribe from a topic in the non-async context
+pub(crate) fn hermes_ipfs_unsubscribe(
+    kind: SubscriptionKind,
+    app_name: &ApplicationName,
+    topic: &PubsubTopic,
+) -> Result<bool, Errno> {
+    let ipfs = HERMES_IPFS.get().ok_or(Errno::ServiceUnavailable)?;
+    tracing::debug!(app_name = %app_name, pubsub_topic = %topic, "unsubscribing from PubSub topic");
+
+    if ipfs.apps.topic_subscriptions_contains(kind, topic) {
+        ipfs.pubsub_unsubscribe_blocking(topic)?;
+
+        ipfs.apps.removed_topic_stream(kind, topic);
+        tracing::debug!(app_name = %app_name, pubsub_topic = %topic, "removed subscription topic
+stream");
+    } else {
+        tracing::debug!(app_name = %app_name, pubsub_topic = %topic, "topic subscription does not
+exist");
+    }
+    ipfs.apps
+        .removed_app_topic_subscription(kind, app_name, topic);
+    Ok(true)
+}
+
+/// Publish message to a topic in the non-async context.
+pub(crate) fn hermes_ipfs_publish(
+    app_name: &ApplicationName,
+    topic: &PubsubTopic,
+    message: MessageData,
+) -> Result<(), Errno> {
+    let ipfs = HERMES_IPFS.get().ok_or(Errno::ServiceUnavailable)?;
+
+    // Log publish attempt with message size
+    tracing::info!(
+    app_name = %app_name,
+    topic = %topic,
+    message_size = message.len(),
+    "📤 Publishing PubSub message"
+    );
+
+    let res = ipfs.pubsub_publish_blocking(topic, message);
+
+    match &res {
+        Ok(()) => {
+            tracing::info!(
+            app_name = %app_name,
+            topic = %topic,
+            "✅ PubSub publish succeeded"
+            );
+        },
+        Err(e) => {
+            tracing::error!(
+            app_name = %app_name,
+            topic = %topic,
+            error = ?e,
+            "❌ PubSub publish failed"
+            );
+        },
+    }
+
+    res
 }

--- a/hermes/bin/src/ipfs/blocking.rs
+++ b/hermes/bin/src/ipfs/blocking.rs
@@ -1,0 +1,98 @@
+use std::{
+    convert::Infallible,
+    sync::{Arc, Mutex},
+};
+
+use catalyst_types::smt::Tree;
+use tokio::{sync::oneshot, task::JoinHandle};
+
+use super::task::IpfsCommand;
+pub(crate) use super::task::SubscriptionKind;
+use crate::{
+    app::ApplicationName,
+    ipfs::HermesIpfsNode,
+    runtime_extensions::{
+        bindings::hermes::ipfs::api::{Errno, MessageData, PeerId, PubsubTopic},
+        hermes,
+    },
+    wasm::module::ModuleId,
+};
+
+impl<N> HermesIpfsNode<N>
+where N: hermes_ipfs::rust_ipfs::NetworkBehaviour<ToSwarm = Infallible> + Send + Sync
+{
+    /// Get the peer identity in a non-async context.
+    pub(super) fn get_peer_identity_blocking(
+        &self,
+        peer: Option<PeerId>,
+    ) -> Result<Option<hermes_ipfs::PeerInfo>, Errno> {
+        let (cmd_tx, cmd_rx) = oneshot::channel();
+        self.sender
+            .as_ref()
+            .ok_or(Errno::GetPeerIdError)?
+            .blocking_send(IpfsCommand::Identity(peer, cmd_tx))
+            .map_err(|_| Errno::GetPeerIdError)?;
+        cmd_rx.blocking_recv().map_err(|_| Errno::GetPeerIdError)?
+    }
+
+    /// Publish message to a `PubSub` topic in the non-async context.
+    pub(super) fn pubsub_publish_blocking(
+        &self,
+        topic: &PubsubTopic,
+        message: MessageData,
+    ) -> Result<(), Errno> {
+        let (cmd_tx, cmd_rx) = oneshot::channel();
+        self.sender
+            .as_ref()
+            .ok_or(Errno::PubsubPublishError)?
+            .blocking_send(IpfsCommand::Publish(topic.clone(), message, cmd_tx))
+            .map_err(|_| Errno::PubsubPublishError)?;
+        cmd_rx
+            .blocking_recv()
+            .map_err(|_| Errno::PubsubPublishError)?
+    }
+
+    /// Subscribe to a `PubSub` topic in a non-async context.
+    pub(super) fn pubsub_subscribe_blocking(
+        &self,
+        kind: SubscriptionKind,
+        topic: &PubsubTopic,
+        tree: Option<Arc<Mutex<Tree<hermes::doc_sync::Cid>>>>,
+        app_name: &ApplicationName,
+        module_ids: Option<&Vec<ModuleId>>,
+    ) -> Result<JoinHandle<()>, Errno> {
+        let (cmd_tx, cmd_rx) = oneshot::channel();
+        let module_ids_owned = module_ids.cloned();
+        self.sender
+            .as_ref()
+            .ok_or(Errno::PubsubSubscribeError)?
+            .blocking_send(IpfsCommand::Subscribe(
+                topic.clone(),
+                kind,
+                tree,
+                app_name.clone(),
+                module_ids_owned,
+                cmd_tx,
+            ))
+            .map_err(|_| Errno::PubsubSubscribeError)?;
+        cmd_rx
+            .blocking_recv()
+            .map_err(|_| Errno::PubsubSubscribeError)?
+    }
+
+    /// Unsubscribe from a `PubSub` topic in the non-async context
+    pub(super) fn pubsub_unsubscribe_blocking(
+        &self,
+        topic: &PubsubTopic,
+    ) -> Result<(), Errno> {
+        let (cmd_tx, cmd_rx) = oneshot::channel();
+        self.sender
+            .as_ref()
+            .ok_or(Errno::PubsubUnsubscribeError)?
+            .blocking_send(IpfsCommand::Unsubscribe(topic.clone(), cmd_tx))
+            .map_err(|_| Errno::PubsubUnsubscribeError)?;
+        cmd_rx
+            .blocking_recv()
+            .map_err(|_| Errno::PubsubUnsubscribeError)?
+    }
+}

--- a/hermes/bin/src/ipfs/doc_sync/reconciliation.rs
+++ b/hermes/bin/src/ipfs/doc_sync/reconciliation.rs
@@ -62,7 +62,7 @@ pub(super) async fn start_reconciliation(
     let syn_payload = make_syn_payload(doc_reconciliation_data, peer).await;
     tracing::info!("SYN payload created");
 
-    if let Err(err) = send_syn_payload(&syn_payload, app_name, channel) {
+    if let Err(err) = send_syn_payload(&syn_payload, app_name, channel).await {
         unsubscribe_from_dif(app_name, channel)?;
         tracing::info!(%channel, "unsubscribed from .dif");
         return Err(err);
@@ -161,7 +161,7 @@ async fn make_syn_payload(
 }
 
 /// Sends the SYN payload to request the reconciliation data.
-fn send_syn_payload(
+async fn send_syn_payload(
     payload: &MsgSyn,
     app_name: &ApplicationName,
     channel: &str,
@@ -172,7 +172,7 @@ fn send_syn_payload(
     payload
         .encode(&mut enc, &mut ())
         .map_err(|e| anyhow::anyhow!("Failed to encode syn_payload::MsgSyn: {e}"))?;
-    hermes_ipfs_publish(app_name, &topic, payload_bytes)?;
+    hermes_ipfs_publish(app_name, &topic, payload_bytes).await?;
     Ok(())
 }
 

--- a/hermes/bin/src/ipfs/doc_sync/reconciliation.rs
+++ b/hermes/bin/src/ipfs/doc_sync/reconciliation.rs
@@ -10,7 +10,7 @@ use crate::{
     app::ApplicationName,
     ipfs::{
         self, api::hermes_ipfs_unsubscribe, hermes_ipfs_get_peer_identity, hermes_ipfs_publish,
-        hermes_ipfs_subscribe,
+        hermes_ipfs_subscribe_blocking,
     },
     runtime_extensions::{
         bindings::hermes::ipfs::api::PeerId,
@@ -79,7 +79,7 @@ fn subscribe_to_dif(
     module_ids: Option<&Vec<ModuleId>>,
 ) -> anyhow::Result<()> {
     let topic = format!("{channel}.dif");
-    hermes_ipfs_subscribe(
+    hermes_ipfs_subscribe_blocking(
         ipfs::SubscriptionKind::DocSync,
         app_name,
         Some(tree),

--- a/hermes/bin/src/ipfs/doc_sync/reconciliation.rs
+++ b/hermes/bin/src/ipfs/doc_sync/reconciliation.rs
@@ -63,7 +63,7 @@ pub(super) async fn start_reconciliation(
     tracing::info!("SYN payload created");
 
     if let Err(err) = send_syn_payload(&syn_payload, app_name, channel).await {
-        unsubscribe_from_dif(app_name, channel)?;
+        unsubscribe_from_dif(app_name, channel).await?;
         tracing::info!(%channel, "unsubscribed from .dif");
         return Err(err);
     }
@@ -92,12 +92,12 @@ async fn subscribe_to_dif(
 }
 
 /// Unsubscribes from ".dif" topic.
-fn unsubscribe_from_dif(
+async fn unsubscribe_from_dif(
     app_name: &ApplicationName,
     channel: &str,
 ) -> anyhow::Result<()> {
     let topic = format!("{channel}.dif");
-    hermes_ipfs_unsubscribe(ipfs::SubscriptionKind::DocSync, app_name, &topic)?;
+    hermes_ipfs_unsubscribe(ipfs::SubscriptionKind::DocSync, app_name, &topic).await?;
     Ok(())
 }
 

--- a/hermes/bin/src/ipfs/doc_sync/topic_handler.rs
+++ b/hermes/bin/src/ipfs/doc_sync/topic_handler.rs
@@ -88,7 +88,9 @@ impl TopicHandler for payload::New {
                                         channel_name,
                                         context.module_ids(),
                                         source.map(|p| p.to_string()),
-                                    ) {
+                                    )
+                                    .await
+                                    {
                                         return Err(anyhow::anyhow!(
                                             "Failed to start reconciliation: {err}",
                                         ));

--- a/hermes/bin/src/ipfs/mod.rs
+++ b/hermes/bin/src/ipfs/mod.rs
@@ -14,6 +14,7 @@ mod api;
 pub(crate) mod blocking;
 mod doc_sync;
 mod task;
+mod topic_handlers;
 mod topic_message_context;
 
 use std::{

--- a/hermes/bin/src/ipfs/mod.rs
+++ b/hermes/bin/src/ipfs/mod.rs
@@ -494,13 +494,10 @@ where N: hermes_ipfs::rust_ipfs::NetworkBehaviour<ToSwarm = Infallible> + Send +
                 .await?;
             tracing::debug!("IPFS node set to DHT server mode");
 
-            // Get the handle to the Tokio runtime
-            let tokio_handle = tokio::runtime::Handle::current();
-
             // Spawn the command handler task
             tokio::spawn(async move {
                 let _ = ready_tx.send(());
-                if let Err(err) = ipfs_command_handler(ipfs, tokio_handle, command_receiver).await {
+                if let Err(err) = ipfs_command_handler(ipfs, command_receiver).await {
                     tracing::error!(%err, "IPFS command handler failed");
 
                     // TODO[rafal-ch]: In the future we should make sure that:

--- a/hermes/bin/src/ipfs/mod.rs
+++ b/hermes/bin/src/ipfs/mod.rs
@@ -11,7 +11,7 @@
 //! - All Hermes nodes should be DHT servers to form a robust P2P network
 
 mod api;
-mod blocking;
+pub(crate) mod blocking;
 mod doc_sync;
 mod task;
 mod topic_message_context;
@@ -45,10 +45,8 @@ const KEYPAIR_FILENAME: &str = "keypair";
 pub(crate) use api::{
     hermes_ipfs_add_file, hermes_ipfs_content_validate, hermes_ipfs_dht_get_providers,
     hermes_ipfs_dht_provide, hermes_ipfs_evict_peer, hermes_ipfs_get_dht_value,
-    hermes_ipfs_get_file, hermes_ipfs_get_peer_identity, hermes_ipfs_get_peer_identity_blocking,
-    hermes_ipfs_pin_file, hermes_ipfs_publish, hermes_ipfs_publish_blocking,
-    hermes_ipfs_put_dht_value, hermes_ipfs_subscribe_blocking, hermes_ipfs_unpin_file,
-    hermes_ipfs_unsubscribe_blocking,
+    hermes_ipfs_get_file, hermes_ipfs_get_peer_identity, hermes_ipfs_pin_file, hermes_ipfs_publish,
+    hermes_ipfs_put_dht_value, hermes_ipfs_unpin_file,
 };
 use catalyst_types::smt::Tree;
 use dashmap::DashMap;

--- a/hermes/bin/src/ipfs/mod.rs
+++ b/hermes/bin/src/ipfs/mod.rs
@@ -481,16 +481,15 @@ where N: hermes_ipfs::rust_ipfs::NetworkBehaviour<ToSwarm = Infallible> + Send +
             }
 
             // Build the Hermes wrapper around IPFS node
-            let hermes_node: HermesIpfs = node.into();
-            hermes_node
-                .dht_mode(hermes_ipfs::rust_ipfs::DhtMode::Server)
+            let ipfs: HermesIpfs = node.into();
+            ipfs.dht_mode(hermes_ipfs::rust_ipfs::DhtMode::Server)
                 .await?;
             tracing::debug!("IPFS node set to DHT server mode");
 
             // Spawn the command handler task
             tokio::spawn(async move {
                 let _ = ready_tx.send(());
-                if let Err(err) = ipfs_command_handler(hermes_node, command_receiver).await {
+                if let Err(err) = ipfs_command_handler(ipfs, command_receiver).await {
                     tracing::error!(%err, "IPFS command handler failed");
 
                     // TODO[rafal-ch]: In the future we should make sure that:

--- a/hermes/bin/src/ipfs/mod.rs
+++ b/hermes/bin/src/ipfs/mod.rs
@@ -11,6 +11,7 @@
 //! - All Hermes nodes should be DHT servers to form a robust P2P network
 
 mod api;
+mod blocking;
 mod doc_sync;
 mod task;
 mod topic_message_context;
@@ -738,20 +739,6 @@ where N: hermes_ipfs::rust_ipfs::NetworkBehaviour<ToSwarm = Infallible> + Send +
             .map_err(|_| Errno::DhtGetProvidersError)?
     }
 
-    /// Get the peer identity in a non-async context.
-    fn get_peer_identity_blocking(
-        &self,
-        peer: Option<PeerId>,
-    ) -> Result<Option<hermes_ipfs::PeerInfo>, Errno> {
-        let (cmd_tx, cmd_rx) = oneshot::channel();
-        self.sender
-            .as_ref()
-            .ok_or(Errno::GetPeerIdError)?
-            .blocking_send(IpfsCommand::Identity(peer, cmd_tx))
-            .map_err(|_| Errno::GetPeerIdError)?;
-        cmd_rx.blocking_recv().map_err(|_| Errno::GetPeerIdError)?
-    }
-
     /// Get the peer identity
     async fn get_peer_identity(
         &self,
@@ -765,23 +752,6 @@ where N: hermes_ipfs::rust_ipfs::NetworkBehaviour<ToSwarm = Infallible> + Send +
             .await
             .map_err(|_| Errno::GetPeerIdError)?;
         cmd_rx.await.map_err(|_| Errno::GetPeerIdError)?
-    }
-
-    /// Publish message to a `PubSub` topic in the non-async context.
-    fn pubsub_publish_blocking(
-        &self,
-        topic: &PubsubTopic,
-        message: MessageData,
-    ) -> Result<(), Errno> {
-        let (cmd_tx, cmd_rx) = oneshot::channel();
-        self.sender
-            .as_ref()
-            .ok_or(Errno::PubsubPublishError)?
-            .blocking_send(IpfsCommand::Publish(topic.clone(), message, cmd_tx))
-            .map_err(|_| Errno::PubsubPublishError)?;
-        cmd_rx
-            .blocking_recv()
-            .map_err(|_| Errno::PubsubPublishError)?
     }
 
     /// Publish message to a `PubSub` topic
@@ -798,34 +768,6 @@ where N: hermes_ipfs::rust_ipfs::NetworkBehaviour<ToSwarm = Infallible> + Send +
             .await
             .map_err(|_| Errno::PubsubPublishError)?;
         cmd_rx.await.map_err(|_| Errno::PubsubPublishError)?
-    }
-
-    /// Subscribe to a `PubSub` topic in a non-async context.
-    fn pubsub_subscribe_blocking(
-        &self,
-        kind: SubscriptionKind,
-        topic: &PubsubTopic,
-        tree: Option<Arc<Mutex<Tree<hermes::doc_sync::Cid>>>>,
-        app_name: &ApplicationName,
-        module_ids: Option<&Vec<ModuleId>>,
-    ) -> Result<JoinHandle<()>, Errno> {
-        let (cmd_tx, cmd_rx) = oneshot::channel();
-        let module_ids_owned = module_ids.cloned();
-        self.sender
-            .as_ref()
-            .ok_or(Errno::PubsubSubscribeError)?
-            .blocking_send(IpfsCommand::Subscribe(
-                topic.clone(),
-                kind,
-                tree,
-                app_name.clone(),
-                module_ids_owned,
-                cmd_tx,
-            ))
-            .map_err(|_| Errno::PubsubSubscribeError)?;
-        cmd_rx
-            .blocking_recv()
-            .map_err(|_| Errno::PubsubSubscribeError)?
     }
 
     /// Subscribe to a `PubSub` topic.
@@ -853,22 +795,6 @@ where N: hermes_ipfs::rust_ipfs::NetworkBehaviour<ToSwarm = Infallible> + Send +
             .await
             .map_err(|_| Errno::PubsubSubscribeError)?;
         cmd_rx.await.map_err(|_| Errno::PubsubSubscribeError)?
-    }
-
-    /// Unsubscribe from a `PubSub` topic in the non-async context
-    fn pubsub_unsubscribe_blocking(
-        &self,
-        topic: &PubsubTopic,
-    ) -> Result<(), Errno> {
-        let (cmd_tx, cmd_rx) = oneshot::channel();
-        self.sender
-            .as_ref()
-            .ok_or(Errno::PubsubUnsubscribeError)?
-            .blocking_send(IpfsCommand::Unsubscribe(topic.clone(), cmd_tx))
-            .map_err(|_| Errno::PubsubUnsubscribeError)?;
-        cmd_rx
-            .blocking_recv()
-            .map_err(|_| Errno::PubsubUnsubscribeError)?
     }
 
     /// Unsubscribe from a `PubSub` topic

--- a/hermes/bin/src/ipfs/mod.rs
+++ b/hermes/bin/src/ipfs/mod.rs
@@ -3,8 +3,8 @@
 //! Why DHT Server Mode is Required:
 //! - DHT (Distributed Hash Table) server mode makes this node actively participate in the
 //!   DHT by storing and serving routing information
-//! - This is REQUIRED for Gossipsub PubSub to work properly because:
-//!   1. PubSub uses the DHT to discover which peers are subscribed to topics
+//! - This is REQUIRED for Gossipsub `PubSub` to work properly because:
+//!   1. `PubSub` uses the DHT to discover which peers are subscribed to topics
 //!   2. Gossipsub builds mesh connections based on DHT peer discovery
 //!   3. Without server mode, the node would be a "leech" that can't help other peers
 //!      discover the network, weakening the mesh

--- a/hermes/bin/src/ipfs/mod.rs
+++ b/hermes/bin/src/ipfs/mod.rs
@@ -469,7 +469,7 @@ where N: hermes_ipfs::rust_ipfs::NetworkBehaviour<ToSwarm = Infallible> + Send +
         // Create a oneshot channel to signal when the command handler is ready
         let (ready_tx, ready_rx) = oneshot::channel();
 
-        // Start the async block.
+        // Start the async block
         tokio_runtime.block_on(async {
             // Spin-up the IPFS node
             let node = builder.start().await?;

--- a/hermes/bin/src/ipfs/task.rs
+++ b/hermes/bin/src/ipfs/task.rs
@@ -99,8 +99,6 @@ pub(crate) enum IpfsCommand {
 #[allow(clippy::too_many_lines)]
 pub(crate) async fn ipfs_command_handler(
     ipfs: HermesIpfs,
-    // TODO[rafal-ch]: Prolly not needed here.
-    _tokio: tokio::runtime::Handle,
     mut queue_rx: mpsc::Receiver<IpfsCommand>,
 ) -> anyhow::Result<()> {
     let ipfs = Arc::new(ipfs);

--- a/hermes/bin/src/ipfs/task.rs
+++ b/hermes/bin/src/ipfs/task.rs
@@ -30,6 +30,7 @@ use crate::{
     wasm::module::ModuleId,
 };
 
+/// Timeout for IPFS identity call
 const IDENTITY_CALL_TIMEOUT: Duration = Duration::from_millis(300);
 
 /// Chooses how subscription messages are handled.

--- a/hermes/bin/src/ipfs/topic_handlers.rs
+++ b/hermes/bin/src/ipfs/topic_handlers.rs
@@ -1,0 +1,151 @@
+use std::{pin::Pin, sync::Arc};
+
+use hermes_ipfs::doc_sync::payload::{self};
+
+use super::HERMES_IPFS;
+use crate::{
+    ipfs::{
+        SubscriptionKind, doc_sync::handle_doc_sync_topic,
+        topic_message_context::TopicMessageContext,
+    },
+    runtime_extensions::{
+        bindings::hermes::ipfs::api::PubsubMessage, hermes::ipfs::event::OnTopicEvent,
+    },
+};
+
+/// A handler for messages from the IPFS pubsub topic
+#[derive(Clone)]
+pub(super) struct TopicMessageHandler {
+    /// The topic.
+    topic: String,
+
+    /// The handler implementation.
+    #[allow(
+        clippy::type_complexity,
+        reason = "to be revisited after the doc sync functionality is fully implemented as this type still evolves"
+    )]
+    callback: Arc<
+        dyn Fn(
+                hermes_ipfs::rust_ipfs::GossipsubMessage,
+                String,
+                TopicMessageContext, /* TODO[rafal-ch]: Should become a borrow, but if not
+                                      * possible, at least an Arc */
+            ) -> Pin<Box<dyn Future<Output = ()> + Send>>
+            + Send
+            + Sync
+            + 'static,
+    >,
+
+    /// The context.
+    context: TopicMessageContext,
+}
+
+impl TopicMessageHandler {
+    /// Creates the new handler.
+    pub fn new<F, Fut>(
+        topic: &str,
+        handler: F,
+        context: TopicMessageContext,
+    ) -> Self
+    where
+        F: Fn(hermes_ipfs::rust_ipfs::GossipsubMessage, String, TopicMessageContext) -> Fut
+            + Send
+            + Sync
+            + 'static,
+        Fut: Future<Output = ()> + Send + 'static,
+    {
+        Self {
+            topic: topic.to_string(),
+            callback: Arc::new(move |msg, topic, ctx| Box::pin(handler(msg, topic, ctx))),
+            context,
+        }
+    }
+
+    /// Forwards the message to the handler.
+    pub async fn handle(
+        &self,
+        msg: hermes_ipfs::rust_ipfs::GossipsubMessage,
+    ) {
+        (self.callback)(msg, self.topic.clone(), self.context.clone()).await;
+    }
+}
+
+/// A handler for subscribe/unsubscribe events from the IPFS pubsub topic
+#[derive(Clone)]
+pub(super) struct TopicSubscriptionStatusHandler<T>
+where T: Fn(hermes_ipfs::SubscriptionStatusEvent, String) + Send + Sync + 'static
+{
+    /// The topic.
+    topic: String,
+
+    /// The handler implementation.
+    callback: T,
+}
+
+impl<T> TopicSubscriptionStatusHandler<T>
+where T: Fn(hermes_ipfs::SubscriptionStatusEvent, String) + Send + Sync + 'static
+{
+    /// Creates the new handler.
+    pub fn new(
+        topic: &impl ToString,
+        callback: T,
+    ) -> Self {
+        Self {
+            topic: topic.to_string(),
+            callback,
+        }
+    }
+
+    /// Passes the subscription event to the handler.
+    pub fn handle(
+        &self,
+        subscription_event: hermes_ipfs::SubscriptionStatusEvent,
+    ) {
+        (self.callback)(subscription_event, self.topic.clone());
+    }
+}
+
+/// Handler function for topic message streams.
+pub(super) async fn topic_message_handler(
+    message: hermes_ipfs::rust_ipfs::GossipsubMessage,
+    topic: String,
+    context: TopicMessageContext,
+) {
+    if let Some(ipfs) = HERMES_IPFS.get() {
+        let app_names = ipfs.apps.subscribed_apps(SubscriptionKind::Default, &topic);
+
+        drop(
+            OnTopicEvent::new(PubsubMessage {
+                topic,
+                message: message.data.into(),
+                publisher: message.source.map(|p| p.to_string()),
+            })
+            .build_and_send(app_names, context.module_ids()),
+        );
+    } else {
+        tracing::error!("Failed to send on_topic_event. IPFS is uninitialized");
+    }
+}
+
+/// Handler for Doc Sync `PubSub` messages.
+#[allow(
+    clippy::needless_pass_by_value,
+    reason = "the other handler consumes the message and we need to keep the signatures consistent"
+)]
+pub(super) async fn doc_sync_topic_message_handler(
+    message: hermes_ipfs::rust_ipfs::GossipsubMessage,
+    topic: String,
+    context: TopicMessageContext,
+) {
+    if let Ok(msg_str) = std::str::from_utf8(&message.data) {
+        tracing::info!(
+            "RECEIVED PubSub message on topic: {topic} - data: {}",
+            &msg_str.chars().take(100).collect::<String>()
+        );
+    }
+
+    let result = handle_doc_sync_topic::<payload::New>(&message, &topic, context).await;
+    if let Some(Err(err)) = result {
+        tracing::error!("Failed to handle IPFS message: {}", err);
+    }
+}

--- a/hermes/bin/src/ipfs/topic_handlers.rs
+++ b/hermes/bin/src/ipfs/topic_handlers.rs
@@ -1,3 +1,7 @@
+//! Hermes IPFS service.
+//!
+//! Handlers for IPFS topics.
+
 use std::{pin::Pin, sync::Arc};
 
 use hermes_ipfs::doc_sync::payload::{self};

--- a/hermes/bin/src/runtime_extensions/hermes/doc_sync/host.rs
+++ b/hermes/bin/src/runtime_extensions/hermes/doc_sync/host.rs
@@ -14,7 +14,7 @@ use wasmtime::component::Resource;
 use super::ChannelState;
 use crate::{
     app::ApplicationName,
-    ipfs::{self, SubscriptionKind, hermes_ipfs_publish, hermes_ipfs_subscribe_blocking},
+    ipfs::{self, SubscriptionKind, hermes_ipfs_publish_blocking, hermes_ipfs_subscribe_blocking},
     runtime_context::HermesRuntimeContext,
     runtime_extensions::{
         bindings::hermes::{
@@ -494,7 +494,7 @@ fn publish_new_payload(
         topic_new
     );
 
-    match hermes_ipfs_publish(ctx.app_name(), &topic_new, payload_bytes) {
+    match hermes_ipfs_publish_blocking(ctx.app_name(), &topic_new, payload_bytes) {
         Ok(()) => {
             tracing::info!("✅ Step {STEP}/{POST_STEP_COUNT}: Published to PubSub → {topic_new}");
             if let Some(timers) = channel_state.timers.as_ref() {
@@ -565,7 +565,7 @@ fn send_new_keepalive(
         .map_err(|e| anyhow::anyhow!("Failed to encode payload::New: {e}"))?;
 
     let new_topic = format!("{channel_name}.new");
-    hermes_ipfs_publish(app_name, &new_topic, payload_bytes)
+    hermes_ipfs_publish_blocking(app_name, &new_topic, payload_bytes)
         .map_err(|e| anyhow::Error::msg(format!("Keepalive publish failed: {e:?}")))?;
     Ok(())
 }

--- a/hermes/bin/src/runtime_extensions/hermes/doc_sync/host.rs
+++ b/hermes/bin/src/runtime_extensions/hermes/doc_sync/host.rs
@@ -14,7 +14,7 @@ use wasmtime::component::Resource;
 use super::ChannelState;
 use crate::{
     app::ApplicationName,
-    ipfs::{self, SubscriptionKind, hermes_ipfs_publish, hermes_ipfs_subscribe},
+    ipfs::{self, SubscriptionKind, hermes_ipfs_publish, hermes_ipfs_subscribe_blocking},
     runtime_context::HermesRuntimeContext,
     runtime_extensions::{
         bindings::hermes::{
@@ -131,7 +131,7 @@ impl HostSyncChannel for HermesRuntimeContext {
             let tree = Arc::clone(&channel_state.smt);
             let topic = format!("{name}{topic_suffix}");
             // When the channel is created, subscribe to two topics: <name>.new and <name>.syn
-            if let Err(err) = hermes_ipfs_subscribe(
+            if let Err(err) = hermes_ipfs_subscribe_blocking(
                 ipfs::SubscriptionKind::DocSync,
                 self.app_name(),
                 Some(tree),
@@ -476,7 +476,7 @@ fn publish_new_payload(
     // is performed in `new()`). Invoking the subscription again to ensure
     // the topic is active, because Gossipsub enforces that peers must subscribe
     // to a topic before they are permitted to publish on it.
-    match hermes_ipfs_subscribe(
+    match hermes_ipfs_subscribe_blocking(
         SubscriptionKind::DocSync,
         ctx.app_name(),
         None,

--- a/hermes/bin/src/runtime_extensions/hermes/ipfs/host.rs
+++ b/hermes/bin/src/runtime_extensions/hermes/ipfs/host.rs
@@ -8,7 +8,7 @@ use crate::{
         hermes_ipfs_dht_provide, hermes_ipfs_evict_peer, hermes_ipfs_get_dht_value,
         hermes_ipfs_get_file, hermes_ipfs_get_peer_identity_blocking, hermes_ipfs_pin_file,
         hermes_ipfs_publish_blocking, hermes_ipfs_put_dht_value, hermes_ipfs_subscribe_blocking,
-        hermes_ipfs_unpin_file, hermes_ipfs_unsubscribe,
+        hermes_ipfs_unpin_file, hermes_ipfs_unsubscribe_blocking,
     },
     runtime_context::HermesRuntimeContext,
     runtime_extensions::bindings::hermes::ipfs::api::{
@@ -123,7 +123,7 @@ impl Host for HermesRuntimeContext {
         &mut self,
         topic: PubsubTopic,
     ) -> wasmtime::Result<Result<bool, Errno>> {
-        Ok(hermes_ipfs_unsubscribe(
+        Ok(hermes_ipfs_unsubscribe_blocking(
             ipfs::SubscriptionKind::Default,
             self.app_name(),
             &topic,

--- a/hermes/bin/src/runtime_extensions/hermes/ipfs/host.rs
+++ b/hermes/bin/src/runtime_extensions/hermes/ipfs/host.rs
@@ -4,11 +4,10 @@ use hermes_ipfs::Cid;
 
 use crate::{
     ipfs::{
-        self, hermes_ipfs_add_file, hermes_ipfs_content_validate, hermes_ipfs_dht_get_providers,
-        hermes_ipfs_dht_provide, hermes_ipfs_evict_peer, hermes_ipfs_get_dht_value,
-        hermes_ipfs_get_file, hermes_ipfs_get_peer_identity_blocking, hermes_ipfs_pin_file,
-        hermes_ipfs_publish_blocking, hermes_ipfs_put_dht_value, hermes_ipfs_subscribe_blocking,
-        hermes_ipfs_unpin_file, hermes_ipfs_unsubscribe_blocking,
+        self, blocking, hermes_ipfs_add_file, hermes_ipfs_content_validate,
+        hermes_ipfs_dht_get_providers, hermes_ipfs_dht_provide, hermes_ipfs_evict_peer,
+        hermes_ipfs_get_dht_value, hermes_ipfs_get_file, hermes_ipfs_pin_file,
+        hermes_ipfs_put_dht_value, hermes_ipfs_unpin_file,
     },
     runtime_context::HermesRuntimeContext,
     runtime_extensions::bindings::hermes::ipfs::api::{
@@ -87,7 +86,7 @@ impl Host for HermesRuntimeContext {
     }
 
     fn get_peer_id(&mut self) -> wasmtime::Result<Result<PeerId, Errno>> {
-        let maybe_identity = hermes_ipfs_get_peer_identity_blocking(None)?;
+        let maybe_identity = blocking::hermes_ipfs_get_peer_identity(None)?;
         match maybe_identity {
             Some(identity) => Ok(Ok(identity.peer_id.to_string())),
             None => Ok(Err(Errno::GetPeerIdError)),
@@ -99,7 +98,7 @@ impl Host for HermesRuntimeContext {
         topic: PubsubTopic,
         message: MessageData,
     ) -> wasmtime::Result<Result<(), Errno>> {
-        Ok(hermes_ipfs_publish_blocking(
+        Ok(blocking::hermes_ipfs_publish(
             self.app_name(),
             &topic,
             message,
@@ -110,7 +109,7 @@ impl Host for HermesRuntimeContext {
         &mut self,
         topic: PubsubTopic,
     ) -> wasmtime::Result<Result<bool, Errno>> {
-        Ok(hermes_ipfs_subscribe_blocking(
+        Ok(blocking::hermes_ipfs_subscribe(
             ipfs::SubscriptionKind::Default,
             self.app_name(),
             None,
@@ -123,7 +122,7 @@ impl Host for HermesRuntimeContext {
         &mut self,
         topic: PubsubTopic,
     ) -> wasmtime::Result<Result<bool, Errno>> {
-        Ok(hermes_ipfs_unsubscribe_blocking(
+        Ok(blocking::hermes_ipfs_unsubscribe(
             ipfs::SubscriptionKind::Default,
             self.app_name(),
             &topic,

--- a/hermes/bin/src/runtime_extensions/hermes/ipfs/host.rs
+++ b/hermes/bin/src/runtime_extensions/hermes/ipfs/host.rs
@@ -7,7 +7,7 @@ use crate::{
         self, hermes_ipfs_add_file, hermes_ipfs_content_validate, hermes_ipfs_dht_get_providers,
         hermes_ipfs_dht_provide, hermes_ipfs_evict_peer, hermes_ipfs_get_dht_value,
         hermes_ipfs_get_file, hermes_ipfs_get_peer_identity_blocking, hermes_ipfs_pin_file,
-        hermes_ipfs_publish, hermes_ipfs_put_dht_value, hermes_ipfs_subscribe_blocking,
+        hermes_ipfs_publish_blocking, hermes_ipfs_put_dht_value, hermes_ipfs_subscribe_blocking,
         hermes_ipfs_unpin_file, hermes_ipfs_unsubscribe,
     },
     runtime_context::HermesRuntimeContext,
@@ -99,7 +99,11 @@ impl Host for HermesRuntimeContext {
         topic: PubsubTopic,
         message: MessageData,
     ) -> wasmtime::Result<Result<(), Errno>> {
-        Ok(hermes_ipfs_publish(self.app_name(), &topic, message))
+        Ok(hermes_ipfs_publish_blocking(
+            self.app_name(),
+            &topic,
+            message,
+        ))
     }
 
     fn pubsub_subscribe(

--- a/hermes/bin/src/runtime_extensions/hermes/ipfs/host.rs
+++ b/hermes/bin/src/runtime_extensions/hermes/ipfs/host.rs
@@ -7,7 +7,7 @@ use crate::{
         self, hermes_ipfs_add_file, hermes_ipfs_content_validate, hermes_ipfs_dht_get_providers,
         hermes_ipfs_dht_provide, hermes_ipfs_evict_peer, hermes_ipfs_get_dht_value,
         hermes_ipfs_get_file, hermes_ipfs_get_peer_identity, hermes_ipfs_pin_file,
-        hermes_ipfs_publish, hermes_ipfs_put_dht_value, hermes_ipfs_subscribe,
+        hermes_ipfs_publish, hermes_ipfs_put_dht_value, hermes_ipfs_subscribe_blocking,
         hermes_ipfs_unpin_file, hermes_ipfs_unsubscribe,
     },
     runtime_context::HermesRuntimeContext,
@@ -104,7 +104,7 @@ impl Host for HermesRuntimeContext {
         &mut self,
         topic: PubsubTopic,
     ) -> wasmtime::Result<Result<bool, Errno>> {
-        Ok(hermes_ipfs_subscribe(
+        Ok(hermes_ipfs_subscribe_blocking(
             ipfs::SubscriptionKind::Default,
             self.app_name(),
             None,


### PR DESCRIPTION
# Description

This PR changes how we use the Tokio async runtime in HermesIPFS. Main changes:
1. Use a single runtime, keep it alive in `HermesIpfsNode`
2. Do not use native OS threads where possible
3. By default, functions are `async`
4. The `*_blocking` counterparts of these functions are available if needed to be called from the non-async context (for example, at startup)
5. Prevent long running `identity` calls from blocking the command queue

## Related Issue(s)

Closes https://github.com/input-output-hk/hermes/issues/788
and potentially a bunch of other bugs related to async handling.

## Description of Changes

See **Description** above.

## Breaking Changes

n/a

## Screenshots

n/a

## Related Pull Requests

n/a

## Please confirm the following checks

* [X] My code follows the style guidelines of this project
* [X] I have performed a self-review of my code
* [X] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [X] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [X] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
